### PR TITLE
fix: fix urlib import error

### DIFF
--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -12,7 +12,7 @@ import weakref
 from operator import itemgetter
 import appdirs
 import time
-import urllib
+import urllib.request
 import zipfile
 import json
 import tempfile


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-
* SENTRY-
* ZENDESK-https://backlight-support.zendesk.com/agent/tickets/162570

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->
using urllib.request has to import urllib.request and not urllib only: https://stackoverflow.com/questions/37042152/python-3-5-1-urllib-has-no-attribute-request

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            