### PR TITLE
fix: Fix framework hooks

### DIFF
--- a/libs/framework-core/hook/discover_ftrack_framework_core.py
+++ b/libs/framework-core/hook/discover_ftrack_framework_core.py
@@ -8,7 +8,6 @@ import logging
 import functools
 
 NAME = 'framework-core'
-VERSION = '0.1.0'
 
 logger = logging.getLogger('{}.hook'.format(NAME.replace('-', '_')))
 
@@ -26,7 +25,7 @@ def on_discover_ftrack_framework_core(session, event):
 
     data = {
         'integration': {
-            'name': 'framework-core',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }

--- a/libs/framework-qt/hook/discover_ftrack_framework_qt.py
+++ b/libs/framework-qt/hook/discover_ftrack_framework_qt.py
@@ -25,7 +25,7 @@ def on_discover_ftrack_framework_qt(session, event):
 
     data = {
         'integration': {
-            'name': 'framework-qt',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }

--- a/projects/framework-3dsmax/hook/discover_ftrack_framework_3dsmax.py
+++ b/projects/framework-3dsmax/hook/discover_ftrack_framework_3dsmax.py
@@ -9,6 +9,8 @@ import importlib
 import ftrack_api
 import functools
 
+NAME = 'framework-3dsmax'
+
 logger = logging.getLogger('ftrack_framework_3dsmax.discover')
 
 
@@ -29,7 +31,7 @@ def on_discover_ftrack_framework_3dsmax(session, event):
 
     data = {
         'integration': {
-            "name": 'framework-3dsmax',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }

--- a/projects/framework-maya/hook/discover_ftrack_framework_maya.py
+++ b/projects/framework-maya/hook/discover_ftrack_framework_maya.py
@@ -7,6 +7,8 @@ import ftrack_api
 import logging
 import functools
 
+NAME = 'framework-maya'
+
 logger = logging.getLogger('ftrack_framework_maya.discover')
 
 plugin_base_dir = os.path.normpath(
@@ -21,7 +23,7 @@ def on_discover_ftrack_framework_maya(session, event):
 
     data = {
         'integration': {
-            "name": 'framework-maya',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }

--- a/projects/framework-nuke/hook/discover_ftrack_framework_nuke.py
+++ b/projects/framework-nuke/hook/discover_ftrack_framework_nuke.py
@@ -7,6 +7,8 @@ import ftrack_api
 import logging
 import functools
 
+NAME = 'framework-nuke'
+
 logger = logging.getLogger('ftrack_framework_nuke.listen_nuke_launch')
 
 plugin_base_dir = os.path.normpath(
@@ -23,7 +25,7 @@ def on_discover_ftrack_framework_nuke(session, event):
 
     data = {
         'integration': {
-            "name": 'framework-nuke',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }

--- a/projects/framework-unreal/hook/discover_ftrack_framework_unreal.py
+++ b/projects/framework-unreal/hook/discover_ftrack_framework_unreal.py
@@ -8,6 +8,8 @@ import logging
 import functools
 import shutil
 
+NAME = 'framework-unreal'
+
 logger = logging.getLogger('ftrack_framework_unreal.discover')
 
 plugin_base_dir = os.path.normpath(
@@ -24,7 +26,7 @@ def on_discover_ftrack_framework_unreal(session, event):
 
     data = {
         'integration': {
-            "name": 'framework-unreal',
+            'name': 'ftrack-{}'.format(NAME),
             'version': integration_version,
         }
     }


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/865cpz12a
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

The Connect DCC launcher does not work due to wrong names reported by each DCC in hook discovery.

## Test

Build and test launcher in Connect, Nuke and other DCC:s should not properly be discovered and launchable.
            