### PR TITLE
feat: auto select plugin mirrors based on latency

### DIFF
--- a/apps/connect/source/ftrack_connect/config.py
+++ b/apps/connect/source/ftrack_connect/config.py
@@ -6,6 +6,12 @@ import logging.config
 import appdirs
 import errno
 
+ENV_PLUGINS_URL = 'FTRACK_CONNECT_JSON_PLUGINS_URL'
+PLUGINS_URLS = [
+    'https://download.ftrack.com/ftrack-connect/plugins.json',
+    'https://ftrack-releases.oss-cn-hangzhou.aliyuncs.com/ftrack-connect/plugins.json',
+]
+
 
 def get_log_directory():
     '''Get log directory.
@@ -17,14 +23,7 @@ def get_log_directory():
     user_data_dir = appdirs.user_data_dir('ftrack-connect', 'ftrack')
     log_directory = os.path.join(user_data_dir, 'log')
 
-    if not os.path.exists(log_directory):
-        try:
-            os.makedirs(log_directory)
-        except OSError as error:
-            if error.errno == errno.EEXIST and os.path.isdir(log_directory):
-                pass
-            else:
-                raise
+    os.makedirs(log_directory, exist_ok=True)
 
     return log_directory
 
@@ -106,3 +105,13 @@ def configure_logging(
 
     # Log out the file output.
     logging.info('Saving log file to: {0}'.format(logfile))
+
+def get_plugins_url():
+    url = os.environ.get(ENV_PLUGINS_URL)
+    if not url:
+        from .util import UrlLatencyChecker
+
+        checker = UrlLatencyChecker(PLUGINS_URLS)
+        url = checker.run()
+    
+    return url

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -2,7 +2,7 @@
 # :copyright: Copyright (c) 2016 ftrack
 
 import os
-from queue import SimpleQueue
+from queue import SimpleQueue, Empty
 import subprocess
 import sys
 import threading
@@ -88,6 +88,8 @@ def invoke_in_main_thread(fn, *args, **kwargs):
     )
 
 class UrlLatencyChecker:
+    MAX_TIMEOUT = 10
+
     def __init__(self, urls: list[str]):
         self.urls = urls
     
@@ -109,5 +111,7 @@ class UrlLatencyChecker:
             t = threading.Thread(target=self._check, args=(url, q), daemon=True)
             t.start()
         
-        url = q.get()
-        return url
+        try:
+            return q.get(timeout=self.MAX_TIMEOUT)
+        except Empty:
+            return self.urls[0]

--- a/projects/connect-plugin-manager/source/ftrack_connect_plugin_manager/__init__.py
+++ b/projects/connect-plugin-manager/source/ftrack_connect_plugin_manager/__init__.py
@@ -15,6 +15,7 @@ import json
 from ftrack_connect.qt import QtWidgets, QtCore, QtGui
 import qtawesome as qta
 
+from ftrack_connect.config import get_plugins_url
 from ftrack_connect.ui.widget.overlay import BlockingOverlay
 
 
@@ -140,17 +141,10 @@ class PluginProcessor(QtCore.QObject):
 
 
 class DndPluginList(QtWidgets.QFrame):
-    default_json_config_url = (
-        'https://download.ftrack.com/ftrack-connect/plugins.json'
-    )
     plugin_re = re.compile('(?P<name>(([A-Za-z-3-4]+)))-(?P<version>(\w.+))')
 
     def __init__(self, session, parent=None):
         super(DndPluginList, self).__init__(parent=parent)
-
-        self.json_config_url = os.environ.get(
-            'FTRACK_CONNECT_JSON_PLUGINS_URL', self.default_json_config_url
-        )
 
         self.default_plugin_directory = appdirs.user_data_dir(
             'ftrack-connect-plugins', 'ftrack'
@@ -291,7 +285,9 @@ class DndPluginList(QtWidgets.QFrame):
     def populate_download_plugins(self):
         '''Populate model with remotely configured plugins.'''
 
-        response = urlopen(self.json_config_url)
+        json_config_url = get_plugins_url()
+        logging.info('using plugins url: %s', json_config_url)
+        response = urlopen(json_config_url)
         response_json = json.loads(response.read())
 
         for link in response_json['integrations']:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/865czyepn

- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [x] Linux.


## Changes

Select plugins url based on the latency of the mirror url.

## Test

login ftrack-connect and install plugins, check logs for selected url.
            