### PR TITLE
feat: Backlog/framework refactor/hide host selector

### DIFF
--- a/framework_hooks/disney/framework-photoshop-widgets/source/ftrack_framework_photoshop_widgets/qt/dialogs/opener_publisher_tab_dialog.py
+++ b/framework_hooks/disney/framework-photoshop-widgets/source/ftrack_framework_photoshop_widgets/qt/dialogs/opener_publisher_tab_dialog.py
@@ -70,6 +70,7 @@ class OpenerPublisherTabDialog(FrameworkDialog, TabDialog):
             dialog_options,
             parent,
         )
+        self.host_connection_selector.hide()
         self._asset_collector_widget = None
         self._tab_mapping = {}
         # This is in a separated method and not in the post_build because the

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/tab_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/tab_dialog.py
@@ -19,6 +19,10 @@ class TabDialog(StyledDialog):
     selected_tab_changed = QtCore.Signal(object)
 
     @property
+    def host_connection_selector(self):
+        return self._host_connection_selector
+
+    @property
     def selected_context_id(self):
         '''Return the selected context id in the context sleector'''
         return self._context_selector.context_id


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/865d7a1ry
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- Host selector is hidden in the opener publisher tab dialog
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            