### PR TITLE
feat: unregister widgets

### DIFF
--- a/libs/framework-widget/source/ftrack_framework_widget/dialog.py
+++ b/libs/framework-widget/source/ftrack_framework_widget/dialog.py
@@ -322,6 +322,15 @@ class FrameworkDialog(BaseUI):
         if widget.id not in list(self.__framework_widget_registry.keys()):
             self.__framework_widget_registry[widget.id] = widget
 
+    def unregister_widget(self, widget_name):
+        '''
+        Remove the given *widget_name* from the registered widgets.
+        '''
+        for widget_id, widget in self.framework_widgets.items():
+            if widget_name == widget.name:
+                self.__framework_widget_registry.pop(widget_id)
+                break
+
     def _connect_dialog_methods_callback(
         self, method_name, arguments=None, callback=None
     ):
@@ -367,6 +376,9 @@ class FrameworkDialog(BaseUI):
         '''
         plugin_info = event['data']['plugin_info']
         plugin_widget_id = plugin_info['plugin_widget_id']
+        if not plugin_widget_id:
+            self.logger.info("Widget id not provided")
+            return
         widget = self.framework_widgets.get(plugin_widget_id)
         if not widget:
             self.logger.error(


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
Dialog is able to unregister registrated widgets.
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            