### PR TITLE
fix: Fix refresh assets on context change

### DIFF
--- a/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/file_browser_collector.py
+++ b/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/file_browser_collector.py
@@ -71,7 +71,3 @@ class FileBrowserWidget(FrameworkWidget, QtWidgets.QWidget):
         asset_changed of asset_selector event is triggered'''
         self.set_plugin_option('folder_path', os.path.dirname(file_path))
         self.set_plugin_option('file_name', os.path.basename(file_path))
-
-    def on_context_updated(self):
-        '''(Override) Do nothing - widget is not context dependent.'''
-        pass

--- a/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/flie_export_options.py
+++ b/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/flie_export_options.py
@@ -89,7 +89,3 @@ class FileExportOptionsWidget(FrameworkWidget, QtWidgets.QWidget):
 
     def _on_option_changed(self, option, value):
         self.set_plugin_option(option, value)
-
-    def on_context_updated(self):
-        '''(Override) Do nothing - widget is not context dependent.'''
-        pass

--- a/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/validator_check.py
+++ b/framework-hooks/framework-core-widgets/source/ftrack_framework_core_widgets/qt/widgets/validator_check.py
@@ -108,7 +108,3 @@ class ValidatorCheckWidget(FrameworkWidget, QtWidgets.QWidget):
         self.plugin_data = {'collector_result': collector_result}
         print(collector_result)
         self.run_plugin_method('validate')
-
-    def on_context_updated(self):
-        '''(Override) Do nothing - widget is not context dependent.'''
-        pass

--- a/libs/framework-widget/source/ftrack_framework_widget/widget.py
+++ b/libs/framework-widget/source/ftrack_framework_widget/widget.py
@@ -139,10 +139,11 @@ class FrameworkWidget(BaseUI):
         )
 
     def on_context_updated(self):
-        '''Called when context of the widget has been updated'''
-        raise NotImplementedError(
-            "This method should be implemented by the inheriting class"
-        )
+        '''Called when context of the widget has been updated.
+        
+        Override to handle context change in inheriting class.
+        '''
+        pass
 
     def set_plugin_option(self, name, value):
         '''


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-865d6wbw1
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Fix bug where change of context did not update framework widgets
