### PR TITLE
fix: issue where scan modules crash on non directories like .zip

### DIFF
--- a/libs/utils/source/ftrack_utils/modules/scan_modules.py
+++ b/libs/utils/source/ftrack_utils/modules/scan_modules.py
@@ -8,7 +8,7 @@ def scan_modules():
     '''Scan sys path and return all modules by lower case name.'''
     result = []
     for path in sys.path:
-        if os.path.exists(path):
+        if os.path.exists(path) and os.path.isdir(path):
             for fn in os.listdir(path):
                 if fn.find('-') > -1:
                     continue


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.



            