### PR TITLE
fix: re-subscribe to discover host when changing context in host

### DIFF
--- a/libs/framework-core/source/ftrack_framework_core/host/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/host/__init__.py
@@ -120,7 +120,7 @@ class Host(object):
         # Need to unsubscribe to make sure we subscribe again with the new
         # context
         self.session.event_hub.unsubscribe(self._discover_host_subscribe_id)
-        # Reply to discover_host_callback to clints to pass the host information
+        # Reply to discover_host_callback to clients to pass the host information
         discover_host_callback_reply = partial(
             provide_host_information,
             self.id,


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/865d6wcdr
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- Update the context id in the host connections when context_id is updated in host. Then once it is re-discovered, its discovered with the new context.
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            