### PR TITLE
fix: lock python version and change development group to documentation

### DIFF
--- a/projects/framework-photoshop/pyproject.toml
+++ b/projects/framework-photoshop/pyproject.toml
@@ -14,17 +14,17 @@ homepage = "https://ftrack.com"
 repository = "https://github.com/ftrackhq/integrations"
 
 [tool.poetry.dependencies]
-python = ">= 3.7, < 3.10"
+python = ">= 3.7, < 3.8"
 PySide2 = "<= 5.16"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry_dynamic_versioning.backend"
 
-[tool.poetry.group.development]
+[tool.poetry.group.documentation]
 optional = true
 
-[tool.poetry.group.development.dependencies]
+[tool.poetry.group.documentation.dependencies]
 pyScss = "^1.2.0"
 Jinja2 = "<3.1"
 sphinx = ">= 1.8.5, < 4"


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-https://app.clickup.com/t/862kg0w6v
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- Lock python version to 3.7 and change development poetry grup to documentation group
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            