### PR TITLE
fix: Fixed bug in version get utility

### DIFF
--- a/libs/utils/pyproject.toml
+++ b/libs/utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-utils"
-version = "2.0.0rc1"
+version = "2.0.0rc2"
 description='ftrack utils library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/utils/source/ftrack_utils/version/__init__.py
+++ b/libs/utils/source/ftrack_utils/version/__init__.py
@@ -28,6 +28,6 @@ def get_version(package_name, package_path):
             "pyproject.toml",
         )
         if os.path.exists(path_toml):
-            version = toml.load(path_toml)["tool"]["poetry"]["version"]
+            result = toml.load(path_toml)["tool"]["poetry"]["version"]
 
-    return version
+    return result


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Fixed bug in utils/version get_version, causing Connect running as a module to not be able to detect its version (removal of _version.py)

## Test

To be tested in Connect

            