### PR TITLE
feat: Backlog/utils version extract

### DIFF
--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -82,3 +82,22 @@ def invoke_in_main_thread(fn, *args, **kwargs):
     QtCore.QCoreApplication.postEvent(
         _invoker, InvokeEvent(fn, *args, **kwargs)
     )
+
+
+def get_connect_plugin_version(connect_plugin_path):
+    '''Return Connect plugin version string for *connect_plugin_path*'''
+    result = None
+    path_version_file = os.path.join(connect_plugin_path, '__version__.py')
+    if not os.path.isfile(path_version_file):
+        raise FileNotFoundError
+    with open(path_version_file) as f:
+        for line in f.readlines():
+            if line.startswith('__version__'):
+                result = line.split('=')[1].strip().strip("'")
+                break
+    if not result:
+        raise Exception(
+            "Can't extract version number from {}. "
+            "\n Make sure file is valid.".format(path_version_file)
+        )
+    return result


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-01d15f54-433f-44e1-bc56-a1d2854cc37e
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Add util to extract connect plugin version number
- Fall back on it when getting version in runtime

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            