### PR TITLE
fix: Bump rc for publish to testpypi

### DIFF
--- a/apps/connect/pyproject.toml
+++ b/apps/connect/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-connect"
-version = "2.1.2rc1"
+version = "2.1.2rc2"
 description='ftrack Connect desktop application.'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"


### PR DESCRIPTION

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Published 2.1.2rc2 to Test pypi

## Test


            