### PR TITLE
feat: Backlog/remove connect dependency comment from widgets

### DIFF
--- a/projects/connect-action-launcher-widget/pyproject.toml
+++ b/projects/connect-action-launcher-widget/pyproject.toml
@@ -21,7 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-ftrack-connect = "> 1, < 3"
 ftrack-utils = { version = "> 1, < 3", optional = true }
 
 [tool.poetry.extras]

--- a/projects/connect-plugin-manager/pyproject.toml
+++ b/projects/connect-plugin-manager/pyproject.toml
@@ -21,8 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-# TODO: connect is a dependnecy of this package we should add it.
-# ftrack-connect = "2.0.0rc1"
 qtawesome = "*"
 ftrack-utils = { version = "> 1, < 3", optional = true }
 

--- a/projects/connect-publisher-widget/pyproject.toml
+++ b/projects/connect-publisher-widget/pyproject.toml
@@ -21,8 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-# TODO: connect is a dependnecy of this package we should add it.
-# ftrack-connect = "2.0.0rc1"
 # TODO: this package seems to be usign the old python api, needs to be reviewed. Check publisher.py line 10 and 11
 ftrack-utils = { version = "> 1, < 3", optional = true }
 

--- a/projects/connect-timetracker-widget/pyproject.toml
+++ b/projects/connect-timetracker-widget/pyproject.toml
@@ -21,8 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-# TODO: connect is a dependnecy of this package we should add it.
-# ftrack-connect = "2.0.0rc1"
 # TODO: this package seems to be usign the old python api,
 qtawesome = "*"
 ftrack-utils = { version = "> 1, < 3", optional = true }


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-50a444ee-4461-47fc-bcdc-6f57fda5c244
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

remove connect dependency comment from widgets

## Test


            