### PR TITLE
fix: Remove legacy ftrack api comment

### DIFF
--- a/projects/connect-publisher-widget/pyproject.toml
+++ b/projects/connect-publisher-widget/pyproject.toml
@@ -21,7 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-# TODO: this package seems to be usign the old python api, needs to be reviewed. Check publisher.py line 10 and 11
 ftrack-utils = { version = "> 1, < 3", optional = true }
 
 [tool.poetry.extras]

--- a/projects/connect-timetracker-widget/pyproject.toml
+++ b/projects/connect-timetracker-widget/pyproject.toml
@@ -21,7 +21,6 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.8"
-# TODO: this package seems to be usign the old python api,
 qtawesome = "*"
 ftrack-utils = { version = "> 1, < 3", optional = true }
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-d70d06c7-5350-4ba4-ad33-11e251933211
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Remove legacy ftrack api comment

## Test


            