### PR TITLE
fix: Backlog/connect with applauncher/fix rv use of app launcher

### DIFF
--- a/apps/connect/source/ftrack_connect/applaunch/__init__.py
+++ b/apps/connect/source/ftrack_connect/applaunch/__init__.py
@@ -1,6 +1,6 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2023 ftrack
-
+import plistlib
 import sys
 import pprint
 import re
@@ -281,6 +281,22 @@ class ApplicationStore(object):
                                     'Could not parse version'
                                     ' {0} from {1}'.format(version, path)
                                 )
+                        elif sys.platform == 'darwin' and path.endswith(
+                            '.app'
+                        ):
+                            # Extract version from Info.plist within .app
+                            # bundle.
+                            plist_path = os.path.join(
+                                path, 'Contents', 'Info.plist'
+                            )
+                            if os.path.isfile(plist_path):
+                                with open(plist_path, 'rb') as f:
+                                    infoPlist = plistlib.load(f)
+                                    version = infoPlist.get(
+                                        'CFBundleShortVersionString'
+                                    )
+                                    if version:
+                                        loose_version = LooseVersion(version)
 
                         variant_str = variant.format(
                             version=str(loose_version)

--- a/projects/rv/doc/release/release_notes.rst
+++ b/projects/rv/doc/release/release_notes.rst
@@ -9,6 +9,11 @@ Release Notes
 
 .. release:: upcoming
 
+    .. change:: fixed
+        :tags: versioning
+
+        Properly detect RV version on mac. Refactored hook to use applaunch module within Connect.
+
     .. change:: changed
 
         Replaced setuptools with Poetry and RV package build tool.


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FTRACK-82f41977-2c8a-468f-8109-4770df71be9f
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

1. Refactored hook to use applaunch module within Connect.
2. Properly detect RV version on mac. 
3. Consolidated hook

## Test


            