### PR TITLE
feat: provide environment variable to drive startup widget…

### DIFF
--- a/apps/connect/doc/release/release_notes.rst
+++ b/apps/connect/doc/release/release_notes.rst
@@ -11,6 +11,11 @@ Release Notes
 .. release:: upcoming
 
     .. change:: changed
+        :tags: Environment Variables
+
+        Provide FTRACK_CONNECT_DISABLE_STARTUP_WIDGET environment variable to drive the startup widget visibility.
+
+    .. change:: changed
 
         Convert Object to QObject to ensure proper livecycle handling in pyside.
 

--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -923,9 +923,9 @@ class Application(QtWidgets.QMainWindow):
         '''Find and load connect widgets in search paths.'''
 
         event = ftrack_api.event.base.Event(topic=ConnectWidgetPlugin.topic)
-
+        disable_startup_widget = bool(os.getenv('FTRACK_CONNECT_DISABLE_STARTUP_WIDGET', False))
         responses = self.session.event_hub.publish(event, synchronous=True)
-        if not responses:
+        if not responses and not disable_startup_widget:
             widget_plugin = WelcomePlugin(self.session)
             identifier = widget_plugin.getIdentifier()
             if not self.plugins.get(identifier):


### PR DESCRIPTION
Provide new FTRACK_CONNECT_DISABLE_STARTUP_WIDGET  environment variable to disable startup widget in case no local plugins are available. This is useful for when connect has centrally installed plugins rather than locally placed in the user plugin folders.