### PR TITLE
fix: slep until event hub is connected

### DIFF
--- a/libs/utils/source/ftrack_utils/decorators/session.py
+++ b/libs/utils/source/ftrack_utils/decorators/session.py
@@ -13,6 +13,7 @@ def with_new_session(func):
         try:
             # Create ftrack session
             session = ftrack_api.Session(auto_connect_event_hub=True)
+            # Avoid connection errors, making sure event hub is connected before continue
             while not session.event_hub.connected:
                 time.sleep(0.1)
             # Add session as argument


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-81591cb9-97bc-4139-8906-bf574413502d
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            