### PR TITLE
feat: added plugin name before reference and group in case of groups

### DIFF
--- a/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
@@ -203,12 +203,12 @@ class Registry(object):
                 tool_config_engine_portion[index] = {
                     'type': 'plugin',
                     'plugin': item,
-                    'reference': uuid.uuid4().hex,
+                    'reference': f'{item}-{uuid.uuid4().hex}',
                 }
                 continue
             elif isinstance(item, dict):
                 if item["type"] == "group":
-                    item['reference'] = uuid.uuid4().hex
+                    item['reference'] = f'{item["type"]}-{uuid.uuid4().hex}'
                     for plugin_item in item.get("plugins", []):
                         if isinstance(plugin_item, str):
                             # Convert string plugin to dictionary
@@ -216,13 +216,15 @@ class Registry(object):
                             item['plugins'][index] = {
                                 'type': 'plugin',
                                 'plugin': plugin_item,
-                                'reference': uuid.uuid4().hex,
+                                'reference': f'{plugin_item}-{uuid.uuid4().hex}',
                             }
                             continue
-                        plugin_item['reference'] = uuid.uuid4().hex
+                        plugin_item[
+                            'reference'
+                        ] = f'{plugin_item["plugin"]}-{uuid.uuid4().hex}'
                         if plugin_item['type'] == "group":
                             self._recursive_create_reference(
                                 plugin_item.get('plugins')
                             )
                 elif item["type"] == "plugin":
-                    item['reference'] = uuid.uuid4().hex
+                    item['reference'] = f'{item["plugin"]}-{uuid.uuid4().hex}'


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-7936711b-33f6-471f-b2a5-0b064a9496f4
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- Added name of the plugin before the reference
- If its a group added group before the reference
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            