### PR TITLE
fix: Entity browser start on initial context

### DIFF
--- a/libs/qt/source/ftrack_qt/widgets/selectors/context_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/context_selector.py
@@ -225,6 +225,7 @@ class ContextSelector(QtWidgets.QFrame):
 
         if self._enable_context_change:
             # Launch browser.
+            self.entity_browser.entity = self.entity
             if self.entity_browser.exec_():
                 self.entity = self.entity_browser.entity
         else:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-9378c299-1d05-42d6-b539-1d7814289079
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Entity browser within Context selector now properly starts on initial context

## Test


            