### PR TITLE
fix: Raise engine exception when plugin fails

### DIFF
--- a/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
@@ -118,8 +118,8 @@ class BaseEngine(object):
         except PluginExecutionError as error:
             plugin_info.status = constants.status.ERROR_STATUS
             plugin_info.message = f"Error executing {plugin}: {error}"
-            # logger the message
-            self.logger.exception(plugin_info.message)
+            # Rise engine error
+            raise EngineExecutionError(message=plugin_info.message)
 
         except PluginValidationError as error:
             plugin_info.status = constants.status.ERROR_STATUS
@@ -135,15 +135,16 @@ class BaseEngine(object):
                     f" An error occurred while applying the fix: {e}"
                 )
                 plugin_info.status = constants.status.ERROR_STATUS
-                self.logger.exception(plugin_info.message)
+                # Rise engine error
+                raise EngineExecutionError(message=plugin_info.message)
 
         except PluginUIHookExecutionError as error:
             plugin_info.status = constants.status.ERROR_STATUS
             plugin_info.message = (
                 f"Error executing ui_hook method of {plugin}: {error}"
             )
-            # logger the message
-            self.logger.exception(plugin_info.message)
+            # Rise engine error
+            raise EngineExecutionError(message=plugin_info.message)
 
         except Exception as error:
             plugin_info.status = constants.status.ERROR_STATUS
@@ -151,8 +152,7 @@ class BaseEngine(object):
                 f"Un-handled exception in {plugin},"
                 f" with options: {options}. Error: {error}"
             )
-            # logger the message
-            self.logger.exception(plugin_info.message)
+            # Rise engine error
             raise EngineExecutionError(message=plugin_info.message)
         finally:
             end_time = time.time()


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-a5e10f23-23be-4dd1-a50e-2cf796535112
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- Raise engine exception when plugin fails
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            