### PR TITLE
fix: Do not tear down progress widget or context selector if dialog closes before they are built.

### DIFF
--- a/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
@@ -184,8 +184,10 @@ class StandardOpenerDialog(BaseContextDialog):
         )
 
     def closeEvent(self, event):
-        '''(Override) Close the progress widget'''
-        self._progress_widget.teardown()
-        self._context_selector.teardown()
-        self._progress_widget.deleteLater()
+        '''(Override) Close the context and progress widgets'''
+        if self._context_selector:
+            self._context_selector.teardown()
+        if self._progress_widget:
+            self._progress_widget.teardown()
+            self._progress_widget.deleteLater()
         super(StandardOpenerDialog, self).closeEvent(event)

--- a/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
@@ -233,8 +233,10 @@ class StandardPublisherDialog(BaseContextDialog):
         )
 
     def closeEvent(self, event):
-        '''(Override) Close the progress widget'''
-        self._progress_widget.teardown()
-        self._context_selector.teardown()
-        self._progress_widget.deleteLater()
+        '''(Override) Close the context and progress widgets'''
+        if self._context_selector:
+            self._context_selector.teardown()
+        if self._progress_widget:
+            self._progress_widget.teardown()
+            self._progress_widget.deleteLater()
         super(StandardPublisherDialog, self).closeEvent(event)


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Do not tear down progress widget or context selector if dialog closes before they are built.

## Test


            