### PR TITLE
feat: Backlog/dock func on run dialog

### DIFF
--- a/libs/framework-core/source/ftrack_framework_core/client/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/client/__init__.py
@@ -348,7 +348,9 @@ class Client(object):
     ):
         '''Function to show a framework dialog by name *dialog_name* from the
         client, using *dialog_class* or picking class from registry. Passes on
-        *dialog_options* to the dialog.'''
+        *dialog_options* to the dialog.
+        *dock_func* is an optional function to dock the dialog in a way for a specific DCC
+        '''
         # use dialog options to pass options to the dialog like for
         #  example: Dialog= WidgetDialog dialog_options= {tool_config_plugin: Context_selector}
         #  ---> So this will execute the widget dialog with the widget of the


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-1641f701-08b0-4182-87eb-32ddfc339198
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
- dock function can be provided to dock any dialog to a DCC
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            