### PR TITLE
fix: overlay parented to framework dialog or to main window

### DIFF
--- a/libs/qt/source/ftrack_qt/utils/widget/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/widget/__init__.py
@@ -7,32 +7,33 @@ from Qt import QtWidgets, QtCore, QtGui
 
 from ftrack_utils.framework.config.tool import get_plugins
 
-# TODO: check this utilities if they are really needed.
+
+def check_framework_dialog_bases(cls):
+    '''Recursively check the base classes for FrameworkDialog.'''
+    for base in cls.__bases__:
+        if base.__name__ == 'FrameworkDialog':
+            return base
+        if check_framework_dialog_bases(base):
+            return base
+    return False
 
 
-def find_parent(widget, class_name):
-    '''Recursively find upstream widget having class name
-    containing *class_name*'''
-    parent_widget = widget.parentWidget()
-    if not parent_widget:
-        return
-    if parent_widget.__class__.__name__.find(class_name) > -1:
-        return parent_widget
-    return find_parent(parent_widget, class_name)
+def get_main_window_from_widget(widget):
+    '''Return the main window from the given widget.'''
+    return widget.window()
 
 
-def get_main_window_from_widget(widget, class_name):
-    '''This function will return the main window from the
-    given *widget*.'''
-    main_window = widget.window()
-    if not main_window:
-        return
-    # Locate the topmost widget
-    parent = find_parent(widget.parentWidget(), class_name)
-    if parent:
-        main_window = parent
+def get_framework_main_dialog(widget):
+    '''Return the main Framework dialog from the given widget.'''
+    main_dialog = None
+    while not main_dialog:
+        widget = widget.parentWidget()
+        if not widget:
+            break
+        if check_framework_dialog_bases(widget.__class__):
+            main_dialog = widget
 
-    return main_window
+    return main_dialog
 
 
 def set_property(widget, name, value):

--- a/libs/qt/source/ftrack_qt/widgets/buttons/options_button.py
+++ b/libs/qt/source/ftrack_qt/widgets/buttons/options_button.py
@@ -5,7 +5,10 @@ from Qt import QtWidgets, QtCore
 
 from ftrack_qt.widgets.overlay import OverlayWidget
 from ftrack_qt.widgets.lines import LineWidget
-from ftrack_qt.utils.widget import get_main_window_from_widget
+from ftrack_qt.utils.widget import (
+    get_main_window_from_widget,
+    get_framework_main_dialog,
+)
 
 
 class OptionsButton(QtWidgets.QPushButton):
@@ -70,9 +73,11 @@ class OptionsButton(QtWidgets.QPushButton):
         self.clicked.connect(self.on_click_callback)
 
     def on_click_callback(self):
-        # TODO: review this, isn't overly widget already checking for the main window??
         '''Callback on clicking the options button, show the publish options overlay'''
-        main_window = get_main_window_from_widget(self, 'base')
+        # Check first if widget is running on a ftrack framework dialog
+        main_window = get_framework_main_dialog(self)
+        if not main_window:
+            main_window = get_main_window_from_widget(self)
         if main_window:
             self._overlay_container.setParent(main_window)
         self._overlay_container.setVisible(True)

--- a/libs/qt/source/ftrack_qt/widgets/overlay/overlay_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/overlay/overlay_widget.py
@@ -3,7 +3,10 @@
 
 from Qt import QtGui, QtCore, QtWidgets
 
-from ftrack_qt.utils.widget import get_main_window_from_widget
+from ftrack_qt.utils.widget import (
+    get_main_window_from_widget,
+    get_framework_main_dialog,
+)
 
 from ftrack_qt.widgets.icons import MaterialIcon
 
@@ -115,14 +118,9 @@ class OverlayWidget(QtWidgets.QFrame):
 
     def setVisible(self, visible):
         '''(Override) Set whether *visible* or not.'''
-        # TODO: double check how we identify the class name, find a better
-        #  solution and more standard, as now is only fining base name which is
-        #  the framework base class name. But I think why should find the top
-        #  level widget by type and not by name, and that type should be given
-        #  in the overlay initialization maybe.
-        main_window = get_main_window_from_widget(
-            self._container_widget, 'base'
-        )
+        main_window = get_framework_main_dialog(self._container_widget)
+        if not main_window:
+            main_window = get_main_window_from_widget(self)
         if visible:
             if not self._event_filter_installed:
                 # Install global event filter that will deal with matching parent size


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-f1894e80-4306-4350-b0f8-dcec4c7f361e
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
Now overlay will try to parent to a framework dialog first, otherwise to the main window.
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            