### PR TITLE
feat: update collected_file to collected path to be aligned

### DIFF
--- a/projects/framework-common-extensions/plugins/collectors/file_collector.py
+++ b/projects/framework-common-extensions/plugins/collectors/file_collector.py
@@ -24,6 +24,6 @@ class FileCollectorPlugin(BasePlugin):
             )
             raise PluginExecutionError(message)
         component_name = self.options.get('component', 'main')
-        store['components'][component_name]['collected_file'] = os.path.join(
+        store['components'][component_name]['collected_path'] = os.path.join(
             folder_path, file_name
         )

--- a/projects/framework-common-extensions/plugins/exporters/rename_file_exporter.py
+++ b/projects/framework-common-extensions/plugins/exporters/rename_file_exporter.py
@@ -9,22 +9,22 @@ from ftrack_framework_core.plugin import BasePlugin
 class RenameExporterPlugin(BasePlugin):
     name = 'rename_file_exporter'
 
-    def rename(self, origin_file, destination_file):
+    def rename(self, origin_path, destination_path):
         '''
-        Rename the given *origin_file to *destination_file*
+        Rename the given *origin_path* to *destination_path*
         '''
-        return shutil.copy(origin_file, os.path.expanduser(destination_file))
+        return shutil.copy(origin_path, os.path.expanduser(destination_path))
 
     def run(self, store):
         '''
-        Expects collected_file in the <component_name> key of the given *store*
+        Expects collected_path in the <component_name> key of the given *store*
         and an export_destination from the :obj:`self.options`.
         '''
         component_name = self.options.get('component')
 
-        collected_file = store['components'][component_name]['collected_file']
+        collected_path = store['components'][component_name]['collected_path']
         export_destination = self.options['export_destination']
 
         store['components'][component_name]['exported_path'] = self.rename(
-            collected_file, export_destination
+            collected_path, export_destination
         )

--- a/projects/framework-common-extensions/plugins/importers/open_file.py
+++ b/projects/framework-common-extensions/plugins/importers/open_file.py
@@ -29,7 +29,7 @@ class OpenFilePlugin(BasePlugin):
 
     def run(self, store):
         '''
-        Expects collected_file in the <component_name> key of the given *store*
+        Expects collected_path in the <component> key of the given *store*
         and an export_destination from the :obj:`self.options`.
         '''
         component_name = self.options.get('component')

--- a/projects/framework-common-extensions/plugins/validators/file_exists_validator.py
+++ b/projects/framework-common-extensions/plugins/validators/file_exists_validator.py
@@ -20,11 +20,11 @@ class FileExistsValidatorPlugin(BasePlugin):
 
     def run(self, store):
         '''
-        Expects collected_file in the <component_name> key of the given *store*.
+        Expects collected_path in the <component_name> key of the given *store*.
         '''
         component_name = self.options.get('component')
-        collected_file = store['components'][component_name]['collected_file']
+        collected_path = store['components'][component_name]['collected_path']
 
-        store['components'][component_name]['valid_file'] = self.validate(
-            collected_file
+        store['components'][component_name]['valid_path'] = self.validate(
+            collected_path
         )


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
Aligns the store collector result collected_file to more standard name: collected_path
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            