### PR TITLE
fix: Fix plugin manager

### DIFF
--- a/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
@@ -189,7 +189,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     @asynchronous
     def _refresh(self, on_init=False):
-        '''Force refresh of the model, fetching all the available plugins.'''
+        '''Force refresh of the model, fetching all the available plugins. This
+        function is run in a separate thread, make sure that UI alterations are
+        performed in QT main thread.'''
         self.refresh_started.emit()
         self._plugin_list_widget.populate_installed_plugins(
             self._on_empty_plugins_callback if on_init else None

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -13,10 +13,12 @@ import qtawesome as qta
 from ftrack_connect.qt import QtWidgets, QtCore, QtGui
 
 from ftrack_connect.util import (
+    qt_main_thread,
     is_conflicting_plugin,
     is_incompatible_plugin,
     is_deprecated_plugin,
     is_loadable_plugin,
+    get_platform_identifier,
 )
 
 from ftrack_connect.plugin_manager.processor import (
@@ -96,6 +98,37 @@ class DndPluginList(QtWidgets.QFrame):
         if not data:
             return
 
+        # Check platform
+        platform = get_platform_identifier()
+        destination_filename = os.path.basename(file_path)
+        if destination_filename.lower().endswith('.zip'):
+            destination_filename = destination_filename[:-4]
+        if data['platform'] != 'noarch':
+            if destination_filename.endswith(f'-{data["platform"]}'):
+                destination_filename = destination_filename[
+                    : -len(data["platform"]) - 1
+                ]
+
+            if data['platform'] != platform:
+                # Ask user if they want to install this plugin
+                msgbox = QtWidgets.QMessageBox(
+                    QtWidgets.QMessageBox.Warning,
+                    'Warning',
+                    'This plugin is not compatible with your platform:'
+                    f':\n\n{destination_filename}\n\nProceed install anyway?',
+                    buttons=QtWidgets.QMessageBox.Yes
+                    | QtWidgets.QMessageBox.No
+                    | QtWidgets.QMessageBox.Cancel,
+                    parent=self,
+                )
+                answer = msgbox.exec_()
+                if answer == QtWidgets.QMessageBox.Yes:
+                    pass
+                elif answer == QtWidgets.QMessageBox.No:
+                    return  # Skip this one, but proceed
+                elif answer == QtWidgets.QMessageBox.Cancel:
+                    raise Exception('Plugin installation cancelled by user.')
+
         loadable = is_loadable_plugin(file_path)
         deprecated = is_deprecated_plugin(file_path)
 
@@ -136,20 +169,18 @@ class DndPluginList(QtWidgets.QFrame):
         if not stored_item:
             # add new plugin
             if status == STATUSES.INSTALLED:
-                plugin_item.setData(file_path, ROLES.PLUGIN_INSTALL_PATH)
+                plugin_item.setData(file_path, ROLES.PLUGIN_INSTALLED_PATH)
                 plugin_item.setEnabled(False)
                 plugin_item.setCheckable(False)
 
             elif status in [STATUSES.NEW, STATUSES.DOWNLOAD]:
-                destination_path = os.path.join(
-                    self.default_plugin_directory, os.path.basename(file_path)
-                )
-
-                plugin_item.setData(
-                    destination_path, ROLES.PLUGIN_INSTALL_PATH
-                )
-
                 plugin_item.setData(file_path, ROLES.PLUGIN_SOURCE_PATH)
+                destination_path = os.path.join(
+                    self.default_plugin_directory, destination_filename
+                )
+                plugin_item.setData(
+                    destination_path, ROLES.PLUGIN_DESTINATION_PATH
+                )
 
                 if status is STATUSES.NEW:
                     # enable it by default as is new.
@@ -175,7 +206,14 @@ class DndPluginList(QtWidgets.QFrame):
             stored_item.setText(f'{stored_item.text()} > {new_plugin_version}')
             stored_item.setData(STATUSES.UPDATE, ROLES.PLUGIN_STATUS)
             stored_item.setIcon(STATUS_ICONS[STATUSES.UPDATE])
+            destination_path = os.path.join(
+                self.default_plugin_directory, destination_filename
+            )
+            stored_item.setData(
+                destination_path, ROLES.PLUGIN_DESTINATION_PATH
+            )
             stored_item.setData(file_path, ROLES.PLUGIN_SOURCE_PATH)
+
             stored_item.setData(new_plugin_version, ROLES.PLUGIN_VERSION)
 
             # enable it by default if we are updating
@@ -202,24 +240,45 @@ class DndPluginList(QtWidgets.QFrame):
         else:
             return False
 
-        if data['version'].endswith('.zip'):
+        data['platform'] = 'noarch'
+        if data['version'].lower().endswith('.zip'):
             # pop zip extension from the version.
             # TODO: refine regex to catch extension
             data['version'] = data['version'][:-4]
+            parts = data['version'].split('-')
+            if len(parts) > 1:
+                data['version'] = parts[0]
+                data['platform'] = parts[-1]
+
         return data
 
-    def populate_installed_plugins(self):
+    @qt_main_thread
+    def populate_installed_plugins(self, empty_plugins_callback=None):
         '''Populate model with installed plugins.'''
         self._plugin_model.clear()
 
         plugins = os.listdir(self.default_plugin_directory)
 
         for plugin in plugins:
-            plugin_path = os.path.join(self.default_plugin_directory, plugin)
-            self.add_plugin(plugin_path, STATUSES.INSTALLED)
+            try:
+                plugin_path = os.path.join(
+                    self.default_plugin_directory, plugin
+                )
+                self.add_plugin(plugin_path, STATUSES.INSTALLED)
+            except Exception as e:
+                logger.exception(e)
+                # Show message box to user
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    'Warning',
+                    f'The following plugin failed to load:\n\n{plugin}\n\n{e}',
+                )
+                logger.warning(f'Failed to add plugin {plugin}: ')
 
-        return len(plugins)
+        if empty_plugins_callback and len(plugins) == 0:
+            empty_plugins_callback()
 
+    @qt_main_thread
     def populate_download_plugins(self):
         '''Populate model with remotely configured plugins.'''
 

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -110,7 +110,7 @@ class DndPluginList(QtWidgets.QFrame):
                 ]
 
             if data['platform'] != platform:
-                # Ask user if they want to install this plugin
+                # Not our platform, ask user if they want to install anyway
                 msgbox = QtWidgets.QMessageBox(
                     QtWidgets.QMessageBox.Warning,
                     'Warning',

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -160,9 +160,7 @@ def invoke_in_qt_main_thread(fn, *args, **kwargs):
     '''
     Invoke function *fn* with arguments, if not running in the main thread.
 
-    TODO: Align this with DCC utility functions to run in main thread, and use them
-    instead as their QT implementation might differ and this solution might not apply
-    or cause instabilities.
+    TODO: Use ftrack QT util instead
     '''
     if QtCore.QThread.currentThread() is _invoker.thread():
         fn(*args, **kwargs)
@@ -173,7 +171,9 @@ def invoke_in_qt_main_thread(fn, *args, **kwargs):
 
 
 def qt_main_thread(func):
-    '''Decorator to ensure the function runs in the QT main thread.'''
+    '''Decorator to ensure the function runs in the QT main thread.
+    TODO: Use ftrack QT util instead
+    '''
 
     def wrapper(*args, **kwargs):
         return invoke_in_qt_main_thread(func, *args, **kwargs)


### PR DESCRIPTION
…drop of platform dependent plugins


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-8c389c6a-c28c-494c-9349-0be13d858a04
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Support drag-n-drop of platform dependent plugins
- Fixed multithreading issue in plugin manager refresh


## Test

Do a full ETE test on plugin manager.
            