### PR TITLE
feat: replace copyright to 2024

### DIFF
--- a/libs/constants/source/ftrack_constants/__init__.py
+++ b/libs/constants/source/ftrack_constants/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 import os
 import logging
 

--- a/libs/constants/source/ftrack_constants/framework/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 # Avoid circular dependencies.
 from ftrack_constants.framework import event

--- a/libs/constants/source/ftrack_constants/framework/asset/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/asset/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: re-check that all the constants in here are used. Remove the unused ones.
 
 #: Name of the ftrack object to identify the loaded assets

--- a/libs/constants/source/ftrack_constants/framework/client/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/client/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 COMPATIBLE_UI_TYPES = ['qt']

--- a/libs/constants/source/ftrack_constants/framework/component/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/component/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 SNAPSHOT_COMPONENT_NAME = 'snapshot'
 FTRACKREVIEW_COMPONENT_NAME = 'ftrackreview'

--- a/libs/constants/source/ftrack_constants/framework/event/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/event/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 #: Run the events of the session in remote mode
 REMOTE_EVENT_MODE = 1

--- a/libs/constants/source/ftrack_constants/framework/plugin/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/plugin/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 # Generic plugins
 #: Generic plugin type for Finalizer plugins

--- a/libs/constants/source/ftrack_constants/framework/tools/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/tools/__init__.py
@@ -1,3 +1,3 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 from ftrack_constants.framework.tools import types

--- a/libs/constants/source/ftrack_constants/framework/tools/types/__init__.py
+++ b/libs/constants/source/ftrack_constants/framework/tools/types/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 # Common tool types.
 

--- a/libs/constants/source/ftrack_constants/qt/__init__.py
+++ b/libs/constants/source/ftrack_constants/qt/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_constants.qt import theme

--- a/libs/constants/source/ftrack_constants/qt/theme/__init__.py
+++ b/libs/constants/source/ftrack_constants/qt/theme/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 DEFAULT_STYLE = 'ftrack'
 DEFAULT_THEME = 'dark'

--- a/libs/constants/source/ftrack_constants/status/__init__.py
+++ b/libs/constants/source/ftrack_constants/status/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 #: Unknown status execution.
 UNKNOWN_STATUS = 'UNKNOWN_STATUS'

--- a/libs/framework-core/doc/resource/custom-location-plugin/location/custom_location_plugin.py
+++ b/libs/framework-core/doc/resource/custom-location-plugin/location/custom_location_plugin.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import functools

--- a/libs/framework-core/doc/resource/custom-location-plugin/location/structure.py
+++ b/libs/framework-core/doc/resource/custom-location-plugin/location/structure.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import sys
 import os

--- a/libs/framework-core/doc/resource/framework-maya/resource/plugins/python/loader/importers/maya_render_loader_importer.py
+++ b/libs/framework-core/doc/resource/framework-maya/resource/plugins/python/loader/importers/maya_render_loader_importer.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/libs/framework-core/doc/resource/framework-maya/resource/plugins/python/publisher/finalisers/common_slack_publisher_post_finalizer.py
+++ b/libs/framework-core/doc/resource/framework-maya/resource/plugins/python/publisher/finalisers/common_slack_publisher_post_finalizer.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 from slack import WebClient

--- a/libs/framework-core/doc/resource/framework-maya/source/ftrack_framework_maya/utils/bootstrap.py
+++ b/libs/framework-core/doc/resource/framework-maya/source/ftrack_framework_maya/utils/bootstrap.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 import os
 import shutil

--- a/libs/framework-core/hook/discover_ftrack_framework_core.py
+++ b/libs/framework-core/hook/discover_ftrack_framework_core.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import sys

--- a/libs/framework-core/source/ftrack_framework_core/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 # Evaluate version and log package version

--- a/libs/framework-core/source/ftrack_framework_core/asset/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/asset/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import unicodedata

--- a/libs/framework-core/source/ftrack_framework_core/asset/asset_info.py
+++ b/libs/framework-core/source/ftrack_framework_core/asset/asset_info.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import json

--- a/libs/framework-core/source/ftrack_framework_core/asset/dcc_object.py
+++ b/libs/framework-core/source/ftrack_framework_core/asset/dcc_object.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import ftrack_constants.framework as constants

--- a/libs/framework-core/source/ftrack_framework_core/client/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/client/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import time
 import logging

--- a/libs/framework-core/source/ftrack_framework_core/client/host_connection.py
+++ b/libs/framework-core/source/ftrack_framework_core/client/host_connection.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import copy

--- a/libs/framework-core/source/ftrack_framework_core/configure_logging.py
+++ b/libs/framework-core/source/ftrack_framework_core/configure_logging.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 import logging
 import logging.config

--- a/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/framework-core/source/ftrack_framework_core/event/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/event/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import threading
 

--- a/libs/framework-core/source/ftrack_framework_core/exceptions/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/exceptions/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.exceptions import plugin
 from ftrack_framework_core.exceptions import engine

--- a/libs/framework-core/source/ftrack_framework_core/exceptions/engine.py
+++ b/libs/framework-core/source/ftrack_framework_core/exceptions/engine.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 
 class EngineExecutionError(Exception):

--- a/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
+++ b/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/framework-core/source/ftrack_framework_core/host/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/host/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import uuid
 import logging

--- a/libs/framework-core/source/ftrack_framework_core/log/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/log/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import logging

--- a/libs/framework-core/source/ftrack_framework_core/log/log_item.py
+++ b/libs/framework-core/source/ftrack_framework_core/log/log_item.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 
 class LogItem(object):

--- a/libs/framework-core/source/ftrack_framework_core/plugin/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/plugin/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 from abc import ABC, abstractmethod

--- a/libs/framework-core/source/ftrack_framework_core/plugin/plugin_info.py
+++ b/libs/framework-core/source/ftrack_framework_core/plugin/plugin_info.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import ftrack_constants as constants
 

--- a/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import uuid
 
 import logging

--- a/libs/framework-core/source/ftrack_framework_core/widget/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/widget/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 
 

--- a/libs/framework-core/source/ftrack_framework_core/widget/dialog.py
+++ b/libs/framework-core/source/ftrack_framework_core/widget/dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import uuid

--- a/libs/framework-core/source/ftrack_framework_core/widget/widget.py
+++ b/libs/framework-core/source/ftrack_framework_core/widget/widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/framework-qt/source/ftrack_framework_qt/__init__.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import logging

--- a/libs/framework-qt/source/ftrack_framework_qt/dialogs/__init__.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/dialogs/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_qt.dialogs.base_context_dialog import BaseContextDialog
 from ftrack_framework_qt.dialogs.base_dialog import BaseDialog

--- a/libs/framework-qt/source/ftrack_framework_qt/dialogs/base_context_dialog.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/dialogs/base_context_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import copy
 
 from Qt import QtWidgets, QtCore

--- a/libs/framework-qt/source/ftrack_framework_qt/dialogs/base_dialog.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/dialogs/base_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/framework-qt/source/ftrack_framework_qt/widgets/__init__.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/widgets/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_qt.widgets.base_widget import BaseWidget

--- a/libs/framework-qt/source/ftrack_framework_qt/widgets/base_widget.py
+++ b/libs/framework-qt/source/ftrack_framework_qt/widgets/base_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt-style/source/ftrack_qt_style/__init__.py
+++ b/libs/qt-style/source/ftrack_qt_style/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 import os
 import logging
 

--- a/libs/qt/source/ftrack_qt/__init__.py
+++ b/libs/qt/source/ftrack_qt/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import logging

--- a/libs/qt/source/ftrack_qt/utils/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/qt/source/ftrack_qt/utils/decorators/threading.py
+++ b/libs/qt/source/ftrack_qt/utils/decorators/threading.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 
 def invoke_in_qt_main_thread(func):

--- a/libs/qt/source/ftrack_qt/utils/layout/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/layout/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 
 def recursive_clear_layout(layout, removed_widgets=[]):

--- a/libs/qt/source/ftrack_qt/utils/theme/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/theme/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import sys
 
 from Qt import QtCore, QtWidgets, QtGui

--- a/libs/qt/source/ftrack_qt/utils/threading/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/threading/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtCore, QtWidgets
 

--- a/libs/qt/source/ftrack_qt/utils/widget/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/widget/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import shiboken2
 

--- a/libs/qt/source/ftrack_qt/widgets/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/qt/source/ftrack_qt/widgets/accordion/accordion_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/accordion/accordion_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/browsers/entity_browser.py
+++ b/libs/qt/source/ftrack_qt/widgets/browsers/entity_browser.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 # TODO: review this widget code and try to simplify it. Review all the utilities
 # as well in the same moment, I think we can simplify it a lot.

--- a/libs/qt/source/ftrack_qt/widgets/browsers/file_browser.py
+++ b/libs/qt/source/ftrack_qt/widgets/browsers/file_browser.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from pathlib import Path
 

--- a/libs/qt/source/ftrack_qt/widgets/buttons/circular_button.py
+++ b/libs/qt/source/ftrack_qt/widgets/buttons/circular_button.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/qt/source/ftrack_qt/widgets/buttons/options_button.py
+++ b/libs/qt/source/ftrack_qt/widgets/buttons/options_button.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/qt/source/ftrack_qt/widgets/buttons/progress_button.py
+++ b/libs/qt/source/ftrack_qt/widgets/buttons/progress_button.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets
 

--- a/libs/qt/source/ftrack_qt/widgets/delegate/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/delegate/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.delegate.asset_version_combo_box_delegate import (
     AssetVersionComboBoxDelegate,

--- a/libs/qt/source/ftrack_qt/widgets/delegate/asset_version_combo_box_delegate.py
+++ b/libs/qt/source/ftrack_qt/widgets/delegate/asset_version_combo_box_delegate.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/file_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/file_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 from Qt import QtWidgets, QtCore

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/modal_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/modal_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import platform
 

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/scroll_tool_configs_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/scroll_tool_configs_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/styled_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/styled_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/tab_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/tab_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/qt/source/ftrack_qt/widgets/frames/asset_version_creation.py
+++ b/libs/qt/source/ftrack_qt/widgets/frames/asset_version_creation.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/frames/asset_version_selection.py
+++ b/libs/qt/source/ftrack_qt/widgets/frames/asset_version_selection.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/frames/new_asset_input.py
+++ b/libs/qt/source/ftrack_qt/widgets/frames/new_asset_input.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 from ftrack_qt.utils.widget import set_property

--- a/libs/qt/source/ftrack_qt/widgets/headers/accordion_header_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/headers/accordion_header_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/headers/session_header.py
+++ b/libs/qt/source/ftrack_qt/widgets/headers/session_header.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtCore, QtWidgets, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/icons/arrow_icon.py
+++ b/libs/qt/source/ftrack_qt/widgets/icons/arrow_icon.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/libs/qt/source/ftrack_qt/widgets/icons/material_icon.py
+++ b/libs/qt/source/ftrack_qt/widgets/icons/material_icon.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 
 from Qt import QtCore, QtWidgets, QtGui, QtSvg

--- a/libs/qt/source/ftrack_qt/widgets/icons/status_icon.py
+++ b/libs/qt/source/ftrack_qt/widgets/icons/status_icon.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: clean this code
 import logging
 

--- a/libs/qt/source/ftrack_qt/widgets/info/entity_info.py
+++ b/libs/qt/source/ftrack_qt/widgets/info/entity_info.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 from Qt import QtWidgets, QtCore

--- a/libs/qt/source/ftrack_qt/widgets/lines/line_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/lines/line_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/lists/asset_list.py
+++ b/libs/qt/source/ftrack_qt/widgets/lists/asset_list.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/qt/source/ftrack_qt/widgets/logos/ftrack_logo.py
+++ b/libs/qt/source/ftrack_qt/widgets/logos/ftrack_logo.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtCore, QtWidgets, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/models/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/models/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.models.table_model import TableModel

--- a/libs/qt/source/ftrack_qt/widgets/models/table_model.py
+++ b/libs/qt/source/ftrack_qt/widgets/models/table_model.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/overlay/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/overlay/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.overlay.busy_indicator import BusyIndicator
 from ftrack_qt.widgets.overlay.shaded_widget import ShadedWidget

--- a/libs/qt/source/ftrack_qt/widgets/overlay/busy_indicator.py
+++ b/libs/qt/source/ftrack_qt/widgets/overlay/busy_indicator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtSvg, QtGui
 import shiboken2

--- a/libs/qt/source/ftrack_qt/widgets/overlay/overlay_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/overlay/overlay_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtGui, QtCore, QtWidgets
 

--- a/libs/qt/source/ftrack_qt/widgets/overlay/shaded_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/overlay/shaded_widget.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/progress/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/progress/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.progress.progress_widget import ProgressWidget

--- a/libs/qt/source/ftrack_qt/widgets/search/collapsable_search_box.py
+++ b/libs/qt/source/ftrack_qt/widgets/search/collapsable_search_box.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtGui, QtCore, QtWidgets
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/context_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/context_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 import shiboken2
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/list_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/list_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/status_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/status_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtGui, QtCore, QtWidgets
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/version_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/version_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 
 from Qt import QtWidgets, QtCore, QtGui

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/asset_version.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/asset_version.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtCore, QtGui, QtWidgets
 

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/base.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/base.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import time
 import os
 import logging

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/context.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/context.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: Clean this code
 
 import urllib.request, urllib.parse, urllib.error

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/ellipse.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/ellipse.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: Clean this code
 
 from Qt import QtCore, QtGui, QtWidgets

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/session_base.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/session_base.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: Clean this code
 import time
 import os

--- a/libs/qt/source/ftrack_qt/widgets/thumbnails/user.py
+++ b/libs/qt/source/ftrack_qt/widgets/thumbnails/user.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: Clean this code
 
 import urllib.request, urllib.parse, urllib.error

--- a/libs/qt/source/ftrack_qt/widgets/user/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/user/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.user.ftrack_user import FtrackUser

--- a/libs/qt/source/ftrack_qt/widgets/user/ftrack_user.py
+++ b/libs/qt/source/ftrack_qt/widgets/user/ftrack_user.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 # TODO: Clean this code
 from Qt import QtCore, QtWidgets, QtGui
 

--- a/libs/qt/source/ftrack_qt/widgets/views/__init__.py
+++ b/libs/qt/source/ftrack_qt/widgets/views/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_qt.widgets.views.table_view import TableView

--- a/libs/qt/source/ftrack_qt/widgets/views/table_view.py
+++ b/libs/qt/source/ftrack_qt/widgets/views/table_view.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/libs/utils/source/ftrack_utils/__init__.py
+++ b/libs/utils/source/ftrack_utils/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack.
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 # Evaluate package version

--- a/libs/utils/source/ftrack_utils/decorators/__init__.py
+++ b/libs/utils/source/ftrack_utils/decorators/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_utils.decorators.session import with_new_session
 from ftrack_utils.decorators.asynchronous import asynchronous

--- a/libs/utils/source/ftrack_utils/decorators/asynchronous.py
+++ b/libs/utils/source/ftrack_utils/decorators/asynchronous.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import threading
 import functools

--- a/libs/utils/source/ftrack_utils/decorators/session.py
+++ b/libs/utils/source/ftrack_utils/decorators/session.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import ftrack_api
 import time

--- a/libs/utils/source/ftrack_utils/directories/__init__.py
+++ b/libs/utils/source/ftrack_utils/directories/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/utils/source/ftrack_utils/directories/scan_dir.py
+++ b/libs/utils/source/ftrack_utils/directories/scan_dir.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/libs/utils/source/ftrack_utils/extensions/__init__.py
+++ b/libs/utils/source/ftrack_utils/extensions/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/utils/source/ftrack_utils/extensions/environment.py
+++ b/libs/utils/source/ftrack_utils/extensions/environment.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/libs/utils/source/ftrack_utils/extensions/registry.py
+++ b/libs/utils/source/ftrack_utils/extensions/registry.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import pkgutil
 import logging

--- a/libs/utils/source/ftrack_utils/framework/__init__.py
+++ b/libs/utils/source/ftrack_utils/framework/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/utils/source/ftrack_utils/framework/config/__init__.py
+++ b/libs/utils/source/ftrack_utils/framework/config/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/utils/source/ftrack_utils/framework/config/tool.py
+++ b/libs/utils/source/ftrack_utils/framework/config/tool.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import copy
 
 

--- a/libs/utils/source/ftrack_utils/framework/remote.py
+++ b/libs/utils/source/ftrack_utils/framework/remote.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 

--- a/libs/utils/source/ftrack_utils/modules/__init__.py
+++ b/libs/utils/source/ftrack_utils/modules/__init__.py
@@ -1,2 +1,2 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack

--- a/libs/utils/source/ftrack_utils/modules/scan_modules.py
+++ b/libs/utils/source/ftrack_utils/modules/scan_modules.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 import sys
 

--- a/libs/utils/source/ftrack_utils/paths/__init__.py
+++ b/libs/utils/source/ftrack_utils/paths/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import clique

--- a/libs/utils/source/ftrack_utils/server/__init__.py
+++ b/libs/utils/source/ftrack_utils/server/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_utils.server.track_usage import send_usage_event
 from ftrack_utils.server.send_event import send_async_event, send_event

--- a/libs/utils/source/ftrack_utils/server/send_event.py
+++ b/libs/utils/source/ftrack_utils/server/send_event.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/utils/source/ftrack_utils/server/track_usage.py
+++ b/libs/utils/source/ftrack_utils/server/track_usage.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 

--- a/libs/utils/source/ftrack_utils/string/__init__.py
+++ b/libs/utils/source/ftrack_utils/string/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import six
 

--- a/libs/utils/source/ftrack_utils/threading/__init__.py
+++ b/libs/utils/source/ftrack_utils/threading/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import threading
 

--- a/libs/utils/source/ftrack_utils/version/__init__.py
+++ b/libs/utils/source/ftrack_utils/version/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 
 

--- a/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-common-extensions/engines/standard_engine.py
+++ b/projects/framework-common-extensions/engines/standard_engine.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.engine import BaseEngine
 

--- a/projects/framework-common-extensions/plugins/component_path_collector.py
+++ b/projects/framework-common-extensions/plugins/component_path_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 from ftrack_framework_core.exceptions.plugin import PluginExecutionError

--- a/projects/framework-common-extensions/plugins/exported_path_validator.py
+++ b/projects/framework-common-extensions/plugins/exported_path_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-common-extensions/plugins/file_collector.py
+++ b/projects/framework-common-extensions/plugins/file_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-common-extensions/plugins/file_exists_validator.py
+++ b/projects/framework-common-extensions/plugins/file_exists_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-common-extensions/plugins/open_file.py
+++ b/projects/framework-common-extensions/plugins/open_file.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import sys

--- a/projects/framework-common-extensions/plugins/publish_to_ftrack.py
+++ b/projects/framework-common-extensions/plugins/publish_to_ftrack.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os
 import traceback
 

--- a/projects/framework-common-extensions/plugins/rename_file_exporter.py
+++ b/projects/framework-common-extensions/plugins/rename_file_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os.path
 import shutil
 

--- a/projects/framework-common-extensions/plugins/store_asset_context.py
+++ b/projects/framework-common-extensions/plugins/store_asset_context.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 from ftrack_framework_core.exceptions.plugin import (

--- a/projects/framework-common-extensions/plugins/store_component.py
+++ b/projects/framework-common-extensions/plugins/store_component.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 

--- a/projects/framework-common-extensions/plugins/store_context_id.py
+++ b/projects/framework-common-extensions/plugins/store_context_id.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 

--- a/projects/framework-common-extensions/widgets/asset_version_selector.py
+++ b/projects/framework-common-extensions/widgets/asset_version_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets
 

--- a/projects/framework-common-extensions/widgets/file_browser_collector.py
+++ b/projects/framework-common-extensions/widgets/file_browser_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import os.path
 
 from Qt import QtWidgets, QtCore, QtGui

--- a/projects/framework-common-extensions/widgets/flie_export_options.py
+++ b/projects/framework-common-extensions/widgets/flie_export_options.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from functools import partial
 

--- a/projects/framework-common-extensions/widgets/publisher_asset_version_selector.py
+++ b/projects/framework-common-extensions/widgets/publisher_asset_version_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/projects/framework-common-extensions/widgets/validator_check.py
+++ b/projects/framework-common-extensions/widgets/validator_check.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore, QtGui
 

--- a/projects/framework-maya/connect-plugin/__version__.py
+++ b/projects/framework-maya/connect-plugin/__version__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 __version__ = '2.0.0rc1'

--- a/projects/framework-maya/connect-plugin/hook/discover_ftrack_framework_maya.py
+++ b/projects/framework-maya/connect-plugin/hook/discover_ftrack_framework_maya.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import ftrack_api

--- a/projects/framework-maya/extensions/plugins/maya_camera_collector.py
+++ b/projects/framework-maya/extensions/plugins/maya_camera_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import maya.cmds as cmds
 
 from ftrack_framework_core.plugin import BasePlugin

--- a/projects/framework-maya/extensions/plugins/maya_camera_exists_validator.py
+++ b/projects/framework-maya/extensions/plugins/maya_camera_exists_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/projects/framework-maya/extensions/plugins/maya_save_to_temp_finalizer.py
+++ b/projects/framework-maya/extensions/plugins/maya_save_to_temp_finalizer.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/projects/framework-maya/extensions/plugins/maya_scene_collector.py
+++ b/projects/framework-maya/extensions/plugins/maya_scene_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/projects/framework-maya/extensions/plugins/maya_scene_exporter.py
+++ b/projects/framework-maya/extensions/plugins/maya_scene_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import maya.cmds as cmds
 
 from ftrack_utils.paths import get_temp_path

--- a/projects/framework-maya/extensions/plugins/maya_scene_opener.py
+++ b/projects/framework-maya/extensions/plugins/maya_scene_opener.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-maya/extensions/plugins/maya_scene_saved_validator.py
+++ b/projects/framework-maya/extensions/plugins/maya_scene_saved_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/projects/framework-maya/extensions/plugins/maya_thumbnail_exporter.py
+++ b/projects/framework-maya/extensions/plugins/maya_thumbnail_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import glob
 import maya.cmds as cmds

--- a/projects/framework-maya/extensions/widgets/maya_camera_selector.py
+++ b/projects/framework-maya/extensions/widgets/maya_camera_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-maya/extensions/widgets/maya_export_options_selector.py
+++ b/projects/framework-maya/extensions/widgets/maya_export_options_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-maya/extensions/widgets/maya_scene_options_selector.py
+++ b/projects/framework-maya/extensions/widgets/maya_scene_options_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-maya/resource/bootstrap/userSetup.py
+++ b/projects/framework-maya/resource/bootstrap/userSetup.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import maya.cmds as cmds
 

--- a/projects/framework-maya/source/ftrack_framework_maya/__init__.py
+++ b/projects/framework-maya/source/ftrack_framework_maya/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 import os
 import traceback

--- a/projects/framework-maya/source/ftrack_framework_maya/utils/__init__.py
+++ b/projects/framework-maya/source/ftrack_framework_maya/utils/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import threading
 from functools import wraps

--- a/projects/framework-nuke/connect-plugin/__version__.py
+++ b/projects/framework-nuke/connect-plugin/__version__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 __version__ = '2.0.0rc1'

--- a/projects/framework-nuke/connect-plugin/hook/discover_ftrack_framework_nuke.py
+++ b/projects/framework-nuke/connect-plugin/hook/discover_ftrack_framework_nuke.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import ftrack_api

--- a/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from PySide2 import QtGui, QtWidgets
 

--- a/projects/framework-nuke/extensions/plugins/nuke_save_to_temp_finalizer.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_save_to_temp_finalizer.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import nuke
 

--- a/projects/framework-nuke/extensions/plugins/nuke_script_collector.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import nuke
 

--- a/projects/framework-nuke/extensions/plugins/nuke_script_exporter.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import nuke
 

--- a/projects/framework-nuke/extensions/plugins/nuke_script_opener.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_opener.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import nuke
 

--- a/projects/framework-nuke/extensions/plugins/nuke_script_saved_validator.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_saved_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import nuke
 

--- a/projects/framework-nuke/extensions/widgets/nuke_script_options_selector.py
+++ b/projects/framework-nuke/extensions/widgets/nuke_script_options_selector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from Qt import QtWidgets, QtCore
 

--- a/projects/framework-nuke/resource/bootstrap/menu.py
+++ b/projects/framework-nuke/resource/bootstrap/menu.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import ftrack_framework_nuke

--- a/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
+++ b/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import os

--- a/projects/framework-nuke/source/ftrack_framework_nuke/utils/__init__.py
+++ b/projects/framework-nuke/source/ftrack_framework_nuke/utils/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from PySide2 import QtWidgets
 

--- a/projects/framework-photoshop/connect-plugin/__version__.py
+++ b/projects/framework-photoshop/connect-plugin/__version__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 __version__ = '1.0.0rc1'

--- a/projects/framework-photoshop/connect-plugin/hook/discover_ftrack_framework_photoshop.py
+++ b/projects/framework-photoshop/connect-plugin/hook/discover_ftrack_framework_photoshop.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import platform
 import os
 import sys

--- a/projects/framework-photoshop/extensions/plugins/document_exporter.py
+++ b/projects/framework-photoshop/extensions/plugins/document_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import tempfile
 import shutil
 

--- a/projects/framework-photoshop/extensions/plugins/document_validator.py
+++ b/projects/framework-photoshop/extensions/plugins/document_validator.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-photoshop/extensions/plugins/image_exporter.py
+++ b/projects/framework-photoshop/extensions/plugins/image_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import tempfile
 
 from ftrack_framework_core.plugin import BasePlugin

--- a/projects/framework-photoshop/extensions/plugins/open_document.py
+++ b/projects/framework-photoshop/extensions/plugins/open_document.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 

--- a/projects/framework-photoshop/extensions/plugins/save_to_temp.py
+++ b/projects/framework-photoshop/extensions/plugins/save_to_temp.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import tempfile
 
 from ftrack_framework_core.plugin import BasePlugin

--- a/projects/framework-photoshop/extensions/widgets/image_options.py
+++ b/projects/framework-photoshop/extensions/widgets/image_options.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from functools import partial
 

--- a/projects/framework-photoshop/source/ftrack_framework_photoshop/__init__.py
+++ b/projects/framework-photoshop/source/ftrack_framework_photoshop/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 import time
 import sys

--- a/projects/framework-photoshop/source/ftrack_framework_photoshop/process_util.py
+++ b/projects/framework-photoshop/source/ftrack_framework_photoshop/process_util.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import sys

--- a/projects/framework-photoshop/source/ftrack_framework_photoshop/rpc_cep.py
+++ b/projects/framework-photoshop/source/ftrack_framework_photoshop/rpc_cep.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import os


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-69fc7d51-7845-4e9b-90dc-a82554986a7d
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
Update copyright to 2024 on all framework related packages
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            