### PR TITLE
fix: remove store from run plugin when sending mix panel event

### DIFF
--- a/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/engine/__init__.py
@@ -92,7 +92,7 @@ class BaseEngine(object):
     @track_framework_usage(
         'FRAMEWORK_RUN_PLUGIN',
         {'module': 'engine'},
-        ['plugin', 'store', 'options'],
+        ['plugin'],
     )
     def run_plugin(self, plugin, store, options, reference=None):
         '''


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-71df35c6-0dd2-4f8e-8c89-a30876cec318
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
Remove store from mixpanel events
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            