### PR TITLE
feat: Backlog/replace pygithub

### DIFF
--- a/apps/connect/pyproject.toml
+++ b/apps/connect/pyproject.toml
@@ -34,7 +34,6 @@ darkdetect = "*"
 certifi = ">=2022,<2023"
 urllib3 = "<2"
 pyyaml = "^6.0.1"
-PyGithub = "^2.0.0"
 
 #ftrack
 ftrack-action-handler = "*"

--- a/apps/connect/source/ftrack_connect/__init__.py
+++ b/apps/connect/source/ftrack_connect/__init__.py
@@ -47,6 +47,9 @@ DEPRECATED_PLUGINS = [
     'ftrack-connect-cinema-4d',
 ]
 
+# ftrack integrations repo URL from were to discover and download plugins
+INTEGRATIONS_REPO = 'https://api.github.com/repos/ftrackhq/integrations'
+
 
 def load_icons(font_folder):
     font_folder = os.path.abspath(font_folder)

--- a/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
@@ -94,10 +94,11 @@ class WelcomeDialog(QtWidgets.QDialog):
         i = 1
         for source_path in source_paths:
             plugin_name = os.path.basename(source_path).split('.zip')[0]
-            # If platform dependent plugin, remove platform identifier before installing
-            plugin_name = plugin_name.replace(
-                f'-{get_platform_identifier()}.', '.'
-            )
+
+            # Remove platform identifier before installing
+            suffix = f'-{get_platform_identifier()}'
+            if plugin_name.endswith(suffix):
+                plugin_name = plugin_name[: -len(suffix)]
 
             destination_path = os.path.join(self.install_path, plugin_name)
             logging.debug(


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-5f3c23ba-01bb-4d5c-b732-ab10583040b9
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Use requests instead of PyGithub to fetch releases from Github.
- Fixed bug in PM welcome dialog plugin install.

## Test

Do a full PM test.
            