### PR TITLE
feat: Remove connect from Connect plugin build filename

### DIFF
--- a/apps/connect/source/ftrack_connect/__init__.py
+++ b/apps/connect/source/ftrack_connect/__init__.py
@@ -32,7 +32,7 @@ CONFLICTING_PLUGINS = [
 ]
 
 # Legacy plugins that is incompatible with Connect and needs to be re-installed
-# if they not are on the new extension format, will not be loaded.
+# if they not are on the new plugin format, will not be loaded.
 INCOMPATIBLE_PLUGINS = [
     'ftrack-connect-publisher-widget',
     'ftrack-connect-timetracker-widget',

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -119,9 +119,9 @@ def is_incompatible_plugin(plugin_path):
     dirname = os.path.basename(plugin_path)
     for incompatible_plugin in INCOMPATIBLE_PLUGINS:
         if dirname.lower().find(incompatible_plugin) > -1:
-            # Check if it has the launch extension
-            launch_path = os.path.join(plugin_path, 'launch')
-            return not os.path.exists(launch_path)
+            # Check if it is a new-style plugin
+            version_path = os.path.join(plugin_path, '__version__.py')
+            return not os.path.exists(version_path)
     return False
 
 

--- a/projects/connect-publisher-widget/pyproject.toml
+++ b/projects/connect-publisher-widget/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = ">= 3.7, < 3.8"
+python = ">= 3.7, < 3.12"
 ftrack-utils = { version = "> 1, < 3", optional = true }
 
 [tool.poetry.extras]

--- a/projects/connect-timetracker-widget/connect-plugin/hook/time_tracker_widget.py
+++ b/projects/connect-timetracker-widget/connect-plugin/hook/time_tracker_widget.py
@@ -3,6 +3,9 @@
 
 import os
 import sys
+
+import ftrack_api
+
 from ftrack_connect.qt import QtWidgets, QtCore, QtGui
 
 import qtawesome as qta

--- a/projects/connect-timetracker-widget/pyproject.toml
+++ b/projects/connect-timetracker-widget/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = ">= 3.7, < 3.8"
+python = ">= 3.7, < 3.12"
 qtawesome = "*"
 ftrack-utils = { version = "> 1, < 3", optional = true }
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -200,9 +200,7 @@ def build_package(pkg_path, args):
 
         STAGING_PATH = os.path.join(
             BUILD_PATH,
-            '{}-{}'.format(
-                PROJECT_NAME.replace('ftrack-connect', 'ftrack'), VERSION
-            ),
+            '{}-{}'.format(PROJECT_NAME, VERSION),
         )
 
         # Clean staging path

--- a/tools/build.py
+++ b/tools/build.py
@@ -215,23 +215,7 @@ def build_package(pkg_path, args):
             raise Exception(
                 'Missing "__version__.py" file in "connect-plugin" folder!'
             )
-        CONNECT_PLUGIN_VERSION = None
-        with open(path_version_file) as f:
-            for line in f.readlines():
-                if line.startswith('__version__'):
-                    CONNECT_PLUGIN_VERSION = (
-                        line.split('=')[1].strip().strip("'")
-                    )
-                    break
-        assert (
-            CONNECT_PLUGIN_VERSION
-        ), 'No version could be extracted from "__version__.py"!'
 
-        logging.info(
-            'Storing Connect plugin version ({})'.format(
-                CONNECT_PLUGIN_VERSION
-            )
-        )
         version_path = os.path.join(STAGING_PATH, '__version__.py')
         shutil.copyfile(path_version_file, version_path)
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -199,7 +199,10 @@ def build_package(pkg_path, args):
             )
 
         STAGING_PATH = os.path.join(
-            BUILD_PATH, '{}-{}'.format(PROJECT_NAME, VERSION)
+            BUILD_PATH,
+            '{}-{}'.format(
+                PROJECT_NAME.replace('ftrack-connect', 'ftrack'), VERSION
+            ),
         )
 
         # Clean staging path
@@ -485,9 +488,7 @@ def build_package(pkg_path, args):
                     )
 
         logging.info('Creating archive')
-        archive_path = os.path.join(
-            BUILD_PATH, '{0}-{1}'.format(PROJECT_NAME, CONNECT_PLUGIN_VERSION)
-        )
+        archive_path = os.path.join(BUILD_PATH, os.path.basename(STAGING_PATH))
         if PLATFORM_DEPENDENT:
             if sys.platform.startswith('win'):
                 archive_path = '{}-windows'.format(archive_path)


### PR DESCRIPTION

<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-e0209055-757a-4fe9-845c-e592236355de
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Remove connect from Connect plugin build filename
- Allow up to Python 3.11 for publisher and timetracker widget
- Fixed missing import in timetracker widget hook

## Test

Build and test publisher and timetracker.
            