### PR TITLE
feat: Consolidate plugin manager welcome dialog logic

### DIFF
--- a/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
@@ -30,7 +30,10 @@ class WelcomeDialog(QtWidgets.QDialog):
         return self._skipped
 
     def __init__(self, install_all_callback, on_restart_callback, parent=None):
-        '''Instantiate the actions widget.'''
+        '''Instantiate the welcome dialog. *install_all_callback* - callback for
+        installing all plugins. *on_restart_callback* - callback for restarting
+        the application after installation. *parent* - parent widget for the dialog
+        '''
         super(WelcomeDialog, self).__init__(parent=parent)
 
         self._install_all_callback = install_all_callback
@@ -38,6 +41,11 @@ class WelcomeDialog(QtWidgets.QDialog):
 
         self._downloadable_plugin_count = 0
         self._skipped = True
+
+        self._install_button = None
+        self._skip = None
+        self._restart_button = None
+        self._overlay = None
 
         self.pre_build()
         self.build()

--- a/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/welcome.py
@@ -1,12 +1,6 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2023 ftrack
 import platformdirs
-import os
-import logging
-import urllib.request
-import zipfile
-import json
-import tempfile
 import qtawesome as qta
 
 from ftrack_connect.qt import QtCore, QtWidgets, QtGui
@@ -16,13 +10,11 @@ from ftrack_utils.decorators import asynchronous
 import ftrack_connect
 from ftrack_connect.util import (
     get_plugin_json_url_from_environment,
-    fetch_github_releases,
-    get_platform_identifier,
 )
 
 
 class WelcomeDialog(QtWidgets.QDialog):
-    '''Welcome plugin dialog - handles empty plugin folder'''
+    '''Welcome plugin dialog - allow user to install all available plugins or skip.'''
 
     plugins_installed = QtCore.Signal()
     installing = QtCore.Signal()
@@ -37,111 +29,33 @@ class WelcomeDialog(QtWidgets.QDialog):
     def skipped(self):
         return self._skipped
 
-    def _discover_plugins(self):
-        '''Provide plugin urls to download'''
-        # Read plugins from json config url if set by user
-        # TODO: remove this when there is a way for users to point plugin manager
-        # to their own repository releases
-        if self.json_config_url:
-            with urllib.request.urlopen(self.json_config_url) as url:
-                data = json.loads(url.read().decode())
-                plugins_url = data.get('integrations')
-
-                if not plugins_url:
-                    self._install_button.setVisible(False)
-                    self._skip.setVisible(False)
-        else:
-            # Read latest releases from ftrack integrations repository
-            releases = fetch_github_releases()
-            plugins_url = []
-            for release in releases:
-                plugins_url.append(release['url'])
-
-        return plugins_url
-
-    def _download_plugins(self, source_paths):
-        '''Download plugins from provided *source_paths* item.'''
-        temp_paths = []
-        self._overlay.message = f"Downloaded 0/{len(source_paths)} plugins."
-        i = 1
-        for source_path in source_paths:
-            zip_name = os.path.basename(source_path)
-            save_path = tempfile.gettempdir()
-            temp_path = os.path.join(save_path, zip_name)
-            logging.debug(
-                'Downloading {} to {}'.format(source_path, temp_path)
-            )
-
-            with urllib.request.urlopen(source_path) as dl_file:
-                with open(temp_path, 'wb') as out_file:
-                    out_file.write(dl_file.read())
-            temp_paths.append(temp_path)
-            self._overlay.message = (
-                f"Downloaded {i}/{len(source_paths)} plugins."
-            )
-            i += 1
-        return temp_paths
-
-    @asynchronous
-    def _install_plugins(self):
-        '''Install all available plugins'''
-        self._skipped = False
-        self.installing.emit()
-        plugins_path = self._discover_plugins()
-        self._overlay.message = f"Discovered {len(plugins_path)} plugins."
-        source_paths = self._download_plugins(plugins_path)
-        self._overlay.message = f"Installed 0/{len(source_paths)} plugins."
-        i = 1
-        for source_path in source_paths:
-            plugin_name = os.path.basename(source_path).split('.zip')[0]
-
-            # Remove platform identifier before installing
-            suffix = f'-{get_platform_identifier()}'
-            if plugin_name.endswith(suffix):
-                plugin_name = plugin_name[: -len(suffix)]
-
-            destination_path = os.path.join(self.install_path, plugin_name)
-            logging.debug(
-                'Installing {} to {}'.format(source_path, destination_path)
-            )
-
-            with zipfile.ZipFile(source_path, 'r') as zip_ref:
-                zip_ref.extractall(destination_path)
-            self._overlay.message = (
-                f"Installed {i}/{len(source_paths)} plugins."
-            )
-            i += 1
-
-        self.plugins_installed.emit()
-
-    def _on_skip_callback(self):
-        '''Skip plugin installation and proceed to connect'''
-        self.close()
-
-    def _on_plugins_installed(self):
-        self._install_button.setVisible(False)
-        self._skip.setVisible(False)
-        self._restart_button.setVisible(True)
-        self._overlay.hide()
-
-    def _on_plugins_installing(self):
-        self._overlay.show()
-
-    def __init__(self, on_restart_callback, parent=None):
+    def __init__(self, install_all_callback, on_restart_callback, parent=None):
         '''Instantiate the actions widget.'''
         super(WelcomeDialog, self).__init__(parent=parent)
+
+        self._install_all_callback = install_all_callback
+        self._on_restart_callback = on_restart_callback
+
+        self._downloadable_plugin_count = 0
         self._skipped = True
 
+        self.pre_build()
+        self.build()
+        self.post_build()
+
+    def pre_build(self):
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(30, 0, 30, 0)
         self.setLayout(layout)
+
+    def build(self):
         spacer = QtWidgets.QSpacerItem(
             0,
             70,
             QtWidgets.QSizePolicy.Minimum,
             QtWidgets.QSizePolicy.Expanding,
         )
-        layout.addItem(spacer)
+        self.layout().addItem(spacer)
 
         icon_label = QtWidgets.QLabel()
         icon = qta.icon(
@@ -174,18 +88,18 @@ class WelcomeDialog(QtWidgets.QDialog):
         label_text.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         label_text.setWordWrap(True)
 
-        layout.addWidget(
+        self.layout().addWidget(
             label_title, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
         )
-        layout.addWidget(
+        self.layout().addWidget(
             icon_label, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
         )
-        layout.addWidget(
+        self.layout().addWidget(
             label_text, QtCore.Qt.AlignCenter | QtCore.Qt.AlignTop
         )
-        layout.addWidget(self._install_button)
-        layout.addWidget(self._skip)
-        layout.addWidget(self._restart_button)
+        self.layout().addWidget(self._install_button)
+        self.layout().addWidget(self._skip)
+        self.layout().addWidget(self._restart_button)
 
         spacer = QtWidgets.QSpacerItem(
             0,
@@ -193,12 +107,14 @@ class WelcomeDialog(QtWidgets.QDialog):
             QtWidgets.QSizePolicy.Minimum,
             QtWidgets.QSizePolicy.Expanding,
         )
-        layout.addItem(spacer)
+        self.layout().addItem(spacer)
+
+    def post_build(self):
         self._install_button.clicked.connect(self._install_plugins)
         self._skip.clicked.connect(self._on_skip_callback)
         self.plugins_installed.connect(self._on_plugins_installed)
         self.installing.connect(self._on_plugins_installing)
-        self._restart_button.clicked.connect(on_restart_callback)
+        self._restart_button.clicked.connect(self._on_restart_callback)
 
         self._overlay = ftrack_connect.ui.widget.overlay.BusyOverlay(
             self, message='Installing'
@@ -209,3 +125,40 @@ class WelcomeDialog(QtWidgets.QDialog):
 
         # Set as modal
         self.setModal(True)
+
+    def set_downloadable_plugin_count(self, count):
+        '''Set the total number of plugins that have been discovered.'''
+        self._downloadable_plugin_count = count
+
+    @asynchronous
+    def _install_plugins(self):
+        '''Install all available plugins by calling the plugin manager'''
+        self._skipped = False
+        self.installing.emit()
+        self._overlay.message = (
+            f"Discovered {self._downloadable_plugin_count} plugins."
+        )
+        self._overlay.message = (
+            f"Installed 0/{self._downloadable_plugin_count} plugins."
+        )
+
+        def plugin_installed_callback(index):
+            self._overlay.message = (
+                f"Installed {index}/{self._downloadable_plugin_count} plugins."
+            )
+
+        self._install_all_callback(plugin_installed_callback)
+        self.plugins_installed.emit()
+
+    def _on_skip_callback(self):
+        '''Skip plugin installation and proceed to connect'''
+        self.close()
+
+    def _on_plugins_installed(self):
+        self._install_button.setVisible(False)
+        self._skip.setVisible(False)
+        self._restart_button.setVisible(True)
+        self._overlay.hide()
+
+    def _on_plugins_installing(self):
+        self._overlay.show()

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -169,7 +169,7 @@ def invoke_in_qt_main_thread(fn, *args, **kwargs):
     TODO: Use ftrack QT util instead
     '''
     if QtCore.QThread.currentThread() is _invoker.thread():
-        fn(*args, **kwargs)
+        return fn(*args, **kwargs)
     else:
         QtCore.QCoreApplication.postEvent(
             _invoker, InvokeEvent(fn, *args, **kwargs)

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -169,7 +169,7 @@ def invoke_in_qt_main_thread(fn, *args, **kwargs):
     TODO: Use ftrack QT util instead
     '''
     if QtCore.QThread.currentThread() is _invoker.thread():
-        return fn(*args, **kwargs)
+        fn(*args, **kwargs)
     else:
         QtCore.QCoreApplication.postEvent(
             _invoker, InvokeEvent(fn, *args, **kwargs)


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-0bcd5140-d584-4da2-8754-30bdf7d6a3c0
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Removed plugin install logic from welcome dialog, instead properly call plugin processor

## Test

Test all edge cases of plugin installation scenarios
            