### PR TITLE
fix: Have build script respect Connect plugin version instead of project version

### DIFF
--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -98,6 +98,7 @@ class DndPluginList(QtWidgets.QFrame):
         pass
 
     # custom methods
+    @qt_main_thread
     def add_plugin(self, file_path, status=STATUSES.NEW):
         '''Add provided *file_path* as plugin with given *status*.'''
         if not file_path:
@@ -262,7 +263,6 @@ class DndPluginList(QtWidgets.QFrame):
 
         return data
 
-    @qt_main_thread
     def populate_installed_plugins(self):
         '''Populate model with installed plugins.'''
         self._installed_plugin_count = 0
@@ -287,7 +287,6 @@ class DndPluginList(QtWidgets.QFrame):
                 )
                 logger.warning(f'Failed to add plugin {plugin}: ')
 
-    @qt_main_thread
     def populate_download_plugins(self):
         '''Populate model with remotely configured plugins.'''
         # Read plugins from json config url if set by user

--- a/tools/build.py
+++ b/tools/build.py
@@ -198,9 +198,32 @@ def build_package(pkg_path, args, command=None):
                 'Could not locate a built python wheel! Please build with Poetry.'
             )
 
+        # Store version
+        path_version_file = os.path.join(CONNECT_PLUGIN_PATH, '__version__.py')
+        if not os.path.isfile(path_version_file):
+            raise Exception(
+                'Missing "__version__.py" file in "connect-plugin" folder!'
+            )
+
+        CONNECT_PLUGIN_VERSION = None
+        with open(path_version_file) as f:
+            for line in f.readlines():
+                if line.startswith('__version__'):
+                    CONNECT_PLUGIN_VERSION = (
+                        line.split('=')[1].strip().strip("'")
+                    )
+                    break
+        assert (
+            CONNECT_PLUGIN_VERSION
+        ), 'No version could be extracted from "__version__.py"!'
+
+        logging.info(
+            'Connect plugin version ({})'.format(CONNECT_PLUGIN_VERSION)
+        )
+
         STAGING_PATH = os.path.join(
             BUILD_PATH,
-            '{}-{}'.format(PROJECT_NAME, VERSION),
+            '{}-{}'.format(PROJECT_NAME, CONNECT_PLUGIN_VERSION),
         )
 
         # Clean staging path
@@ -208,13 +231,6 @@ def build_package(pkg_path, args, command=None):
             logging.info('Cleaning up {}'.format(STAGING_PATH))
             shutil.rmtree(STAGING_PATH, ignore_errors=True)
         os.makedirs(os.path.join(STAGING_PATH))
-
-        # Store version
-        path_version_file = os.path.join(CONNECT_PLUGIN_PATH, '__version__.py')
-        if not os.path.isfile(path_version_file):
-            raise Exception(
-                'Missing "__version__.py" file in "connect-plugin" folder!'
-            )
 
         version_path = os.path.join(STAGING_PATH, '__version__.py')
         shutil.copyfile(path_version_file, version_path)


### PR DESCRIPTION


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

- Have build script respect Connect plugin version instead of project version
- Fix race condition in plugin manager


## Test

            