### PR TITLE
feat: Backlog/build libs on tag

### DIFF
--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -1,0 +1,123 @@
+# On Tag creation:
+#  - Build and publishes libraries to PyPi
+
+name: CI-RELEASE-LIB
+
+on:
+  push:
+    tags:
+      - 'constants/v*' # Push on package tag with version number
+      - 'framework-core/v*'
+      - 'framework-qt/v*'
+      - 'qt/v*'
+      - 'qt-style/v*'
+      - 'utils/v*'
+
+jobs:
+
+  # Set the environment variables for the rest of release workflow
+  set-variables:
+    runs-on: ubuntu-latest
+    outputs:
+      to_pypi: ${{ env.TO_PYPI }}
+      folder: ${{ env.FOLDER }}
+      package: ${{ env.PACKAGE }}
+      version: ${{ env.VERSION }}
+      tag: ${{ env.TAG }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: set environments on full release
+        shell: bash
+        run: |
+          echo "PACKAGE=$(echo ${{ github.ref }} | cut -d/ -f 3-3)" >> $GITHUB_ENV
+          echo "VERSION=$(echo ${{ github.ref }} | cut -d/ -f 4-4)" >> $GITHUB_ENV
+          echo "TAG=$(echo ${{ github.ref }} | cut -d/ -f 3-4)" >> $GITHUB_ENV
+      - name: set lib folder
+        if: ${{ env.PACKAGE == 'constants' || env.PACKAGE == 'framework-core' || env.PACKAGE == 'framework-qt' || env.PACKAGE == 'qt' || env.PACKAGE == 'qt-style' || env.PACKAGE == 'utils' }}
+        shell: bash
+        run: |
+          echo "FOLDER=libs/${{ env.PACKAGE }}" >> $GITHUB_ENV
+          echo "TO_PYPI=true" >> $GITHUB_ENV
+      - name: debug
+        shell: bash
+        run: |
+          echo 'TO_PYPI: ${{ env.TO_PYPI }}'
+          echo 'FOLDER: ${{ env.FOLDER }}'
+          echo 'PACKAGE: ${{ env.PACKAGE }}'
+          echo 'VERSION: ${{ env.VERSION }}'
+          echo 'TAG: ${{ env.TAG }}'
+
+  build-linux:
+    name: Build platform independent artifacts, and Linux specific artifacts
+    needs: set-variables
+    concurrency:
+      group: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    outputs:
+      to_pypi: ${{ needs.set-variables.outputs.to_pypi }}
+      package: ${{ needs.set-variables.outputs.package }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.7'
+      - name: install poetry
+        shell: bash
+        run: |
+          pip install poetry==1.5.1
+      - name: build style
+        if: ${{ needs.set-variables.outputs.package == 'qt-style' }}
+        shell: bash
+        run: |
+          pip install -r tools/requirements.txt
+          python tools/build.py build_qt_resources libs/qt-style
+      - name: poetry build
+        shell: bash
+        run: |
+          cd ${{ needs.set-variables.outputs.folder }}
+          poetry build
+      - name: Upload temp artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ needs.set-variables.outputs.to_pypi == 'true' }}
+        with:
+          name: dist
+          path: ${{ needs.set-variables.outputs.folder }}/dist
+
+  publish-test:
+    name: Publish to PyPi (test)
+    runs-on: ubuntu-latest
+    needs: build-linux
+    if: ${{ needs.build-linux.outputs.to_pypi == 'true' }}
+    environment:
+      name: staging
+      url: https://test.pypi.org/project/ftrack-${{ needs.build-linux.outputs.package }}/
+    steps:
+      - name: Download temp artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Publish to Test PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  publish-prod:
+    name: Publish to PyPi (prod)
+    runs-on: ubuntu-latest
+    needs: build-linux
+    if: ${{ needs.build-linux.outputs.to_pypi == 'true' }}
+    environment:
+      name: production
+      url: https://pypi.org/project/ftrack-${{ needs.build-linux.outputs.package }}/
+    steps:
+      - name: Download temp artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/libs/framework-widget/release_notes.md
+++ b/libs/framework-widget/release_notes.md
@@ -1,6 +1,0 @@
-# ftrack Framework Widget library release Notes
-
-## Upcoming
-YYYY-mm-dd
-
-*  [new] Initial release.

--- a/libs/utils/pyproject.toml
+++ b/libs/utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-utils"
-version = "2.0.0rc7"
+version = "2.0.0rc8"
 description='ftrack utils library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-75cc82e9-217c-40a4-abca-0ded45024e03
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes
If tag is pushed for a library it automatically builds and publish to pypi.
<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            