### PR TITLE
feat: Have utils get_temp_path take on extension with or without .

### DIFF
--- a/libs/utils/release_notes.md
+++ b/libs/utils/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Utils library release Notes
 
+## Upcoming
+
+* [change] get_temp_path util now supports filename_extension with or without leading dot(.)
+
+
 ## V2.0.0
 2024-02-12
 

--- a/libs/utils/release_notes.md
+++ b/libs/utils/release_notes.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
-* [change] get_temp_path util now supports filename_extension with or without leading dot(.)
+* [changed] get_temp_path util now supports filename_extension with or without leading dot(.)
 
 
 ## V2.0.0

--- a/libs/utils/source/ftrack_utils/paths/__init__.py
+++ b/libs/utils/source/ftrack_utils/paths/__init__.py
@@ -45,9 +45,11 @@ def get_temp_path(filename_extension=None):
         tempfile.gettempdir(),
         'ftrack-connect',
         'ftrack',
-        '{}.{}'.format(
+        '{}{}'.format(
             os.path.basename(tempfile.NamedTemporaryFile().name),
-            filename_extension.split(".")[-1] if filename_extension else '',
+            f'.{filename_extension.split(".")[-1]}'
+            if filename_extension
+            else '',
         ),
     )
     if not os.path.exists(os.path.dirname(result)):

--- a/libs/utils/source/ftrack_utils/paths/__init__.py
+++ b/libs/utils/source/ftrack_utils/paths/__init__.py
@@ -41,19 +41,13 @@ def get_temp_path(filename_extension=None):
     '''Calculate and return a Connect temporary path,
     appending *filename_extension* if supplied.'''
 
-    suffix = ''
-    if filename_extension:
-        suffix = '{}{}'.format(
-            '.' if not filename_extension.startswith('.') else '',
-            filename_extension,
-        )
     result = os.path.join(
         tempfile.gettempdir(),
         'ftrack-connect',
         'ftrack',
-        '{}{}'.format(
+        '{}.{}'.format(
             os.path.basename(tempfile.NamedTemporaryFile().name),
-            suffix,
+            filename_extension.split(".")[-1] if filename_extension else '',
         ),
     )
     if not os.path.exists(os.path.dirname(result)):

--- a/libs/utils/source/ftrack_utils/paths/__init__.py
+++ b/libs/utils/source/ftrack_utils/paths/__init__.py
@@ -41,13 +41,19 @@ def get_temp_path(filename_extension=None):
     '''Calculate and return a Connect temporary path,
     appending *filename_extension* if supplied.'''
 
+    suffix = ''
+    if filename_extension:
+        suffix = '{}{}'.format(
+            '.' if not filename_extension.startswith('.') else '',
+            filename_extension,
+        )
     result = os.path.join(
         tempfile.gettempdir(),
         'ftrack-connect',
         'ftrack',
         '{}{}'.format(
             os.path.basename(tempfile.NamedTemporaryFile().name),
-            filename_extension if filename_extension else '',
+            suffix,
         ),
     )
     if not os.path.exists(os.path.dirname(result)):


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-aace4104-514b-4fd5-9d0d-a61c374c9e28
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Have utils get_temp_path take on extension with or without leading .

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            