### PR TITLE
fix: Fix bug when signing a msi with space in filename

### DIFF
--- a/installers/connect-installer/setup.py
+++ b/installers/connect-installer/setup.py
@@ -799,7 +799,7 @@ def clean_download_dir():
 
 def codesign_windows(path):
     '''Codesign artifact *path* using jsign tool in Windows'''
-    return_code = os.system(f'codesign.bat {path}')
+    return_code = os.system(f'codesign.bat "{path}"')
     logging.info(f'Exitcode from code sign: {return_code}')
 
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

Fix bug when signing a msi with space in filename
            