### PR TITLE
fix: Backlog/fix ftrack plugin path in connect installer

### DIFF
--- a/apps/connect/source/ftrack_connect/__init__.py
+++ b/apps/connect/source/ftrack_connect/__init__.py
@@ -4,6 +4,9 @@
 import os
 import logging
 import qtawesome as qta
+import re
+
+logger = logging.getLogger(__name__)
 
 # Evaluate version and log package version
 try:
@@ -16,11 +19,30 @@ try:
 except Exception:
     import traceback
 
-    print(traceback.format_exc())
+    logging.warning(traceback.format_exc())
     __version__ = "0.0.0"
 
+if (
+    __version__ == "0.0.0"
+    and 'FTRACK_CONNECT_INSTALLER_RESOURCE_PATH' in os.environ
+):
+    # If the version is still 0.0.0, we are probably running as executable from within
+    # the installer. In this case, we can use the version stored by the installer.
+    FTRACK_CONNECT_INSTALLER_RESOURCE_PATH = os.environ.get(
+        'FTRACK_CONNECT_INSTALLER_RESOURCE_PATH',
+        os.path.abspath(os.path.join(os.path.dirname(__file__), '..')),
+    )
 
-logger = logging.getLogger(__name__)
+    with open(
+        os.path.join(
+            FTRACK_CONNECT_INSTALLER_RESOURCE_PATH,
+            'ftrack_connect_version.py',
+        )
+    ) as _version_file:
+        __version__ = re.match(
+            r'.*__version__ = \'(.*?)\'', _version_file.read(), re.DOTALL
+        ).group(1)
+
 
 _resource = {"loaded": False}
 

--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -1093,8 +1093,11 @@ class Application(QtWidgets.QMainWindow):
                 if isinstance(response, dict):
                     responses.append(response)
                 elif isinstance(response, list):
-                    responses = response
+                    responses.extend(response)
             for response in responses:
+                if response.get('core'):
+                    result.append(response)
+                    continue
                 found = False
                 for plugin_data in result:
                     if plugin_data['name'] == response['name']:
@@ -1110,7 +1113,7 @@ class Application(QtWidgets.QMainWindow):
         current_plugins_path = [plugin['path'] for plugin in self.plugins]
         # Highlight compatibility and source of plugins
         for plugin_data in result:
-            if plugin_data.get('core'):
+            if plugin_data.get('core') or 'path' not in plugin_data:
                 continue
             tags = []
             if plugin_data.get('incompatible'):

--- a/apps/connect/source/ftrack_connect/ui/widget/about.py
+++ b/apps/connect/source/ftrack_connect/ui/widget/about.py
@@ -164,7 +164,9 @@ class AboutDialog(QtWidgets.QDialog):
         '''Set displayed *versionData*, *user*, *server*.'''
         core = [plugin for plugin in versionData if plugin.get('core')]
         plugins = [
-            plugin for plugin in versionData if plugin.get('core') is not True
+            plugin
+            for plugin in versionData
+            if 'path' in plugin and plugin.get('core') is not True
         ]
 
         coreTemplate = '''

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -283,7 +283,13 @@ def check_major_version(version, major_version_start=24):
         major_version = int(match.group(1))
         return major_version >= major_version_start
     else:
-        return False
+        # Could be without patch
+        match = re.match(r'v(\d+)\.\d+\.*', version)
+        if match:
+            major_version = int(match.group(1))
+            return major_version >= major_version_start
+        else:
+            return False
 
 
 def fetch_github_releases(latest=True, prereleases=False):
@@ -319,7 +325,7 @@ def fetch_github_releases(latest=True, prereleases=False):
             # TODO: solve the issue when library major version is catching up to
             #  Connect major version
             logger.debug(
-                f'   Not a Connect release on YY.m.p format: {tag_name} \n '
+                f'   Not a Connect release on YY.m.p|YY.mp format: {tag_name} \n '
                 f'Minimum compatible major version is 24.X.X'
             )
             continue

--- a/apps/connect/source/ftrack_connect/util.py
+++ b/apps/connect/source/ftrack_connect/util.py
@@ -279,17 +279,16 @@ def get_plugin_json_url_from_environment():
 
 def check_major_version(version, major_version_start=24):
     match = re.match(r'v(\d+)\.\d+\.\d+.*', version)
+    no_path_match = re.match(r'v(\d+)\.\d+\.*', version)
     if match:
         major_version = int(match.group(1))
         return major_version >= major_version_start
+    elif no_path_match:
+        # Without patch
+        major_version = int(no_path_match.group(1))
+        return major_version >= major_version_start
     else:
-        # Could be without patch
-        match = re.match(r'v(\d+)\.\d+\.*', version)
-        if match:
-            major_version = int(match.group(1))
-            return major_version >= major_version_start
-        else:
-            return False
+        return False
 
 
 def fetch_github_releases(latest=True, prereleases=False):

--- a/installers/connect-installer/doc/conf.py
+++ b/installers/connect-installer/doc/conf.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 '''ftrack connect installer documentation build configuration file.'''
 

--- a/installers/connect-installer/docker/C7.Dockerfile
+++ b/installers/connect-installer/docker/C7.Dockerfile
@@ -1,5 +1,5 @@
 #########################################################################
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 #
 
 FROM inveniosoftware/centos7-python:3.6

--- a/installers/connect-installer/docker/C8.Dockerfile
+++ b/installers/connect-installer/docker/C8.Dockerfile
@@ -1,5 +1,5 @@
 #########################################################################
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 #
 
 FROM inveniosoftware/centos8-python:3.7

--- a/installers/connect-installer/docker/README.rst
+++ b/installers/connect-installer/docker/README.rst
@@ -1,4 +1,4 @@
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 Docker for building ftrack-connect-installer
 ==========================================

--- a/installers/connect-installer/docker/Win10.Dockerfile
+++ b/installers/connect-installer/docker/Win10.Dockerfile
@@ -1,6 +1,6 @@
 # escape=`
 #########################################################################
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 #
 
 FROM winamd64/python:3.7

--- a/installers/connect-installer/resource/hook/ftrack_connect_installer_version_information.py
+++ b/installers/connect-installer/resource/hook/ftrack_connect_installer_version_information.py
@@ -27,7 +27,7 @@ with open(
 
 def get_version_information(event):
     '''Return version information for ftrack connect installer.'''
-    return [dict(name='Package', version=VERSION, core=True)]
+    return [dict(name='Installer', version=VERSION, core=True)]
 
 
 def register(api_object, **kw):

--- a/installers/connect-installer/resource/hook/ftrack_connect_installer_version_information.py
+++ b/installers/connect-installer/resource/hook/ftrack_connect_installer_version_information.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import logging
 import os
@@ -32,10 +32,6 @@ def get_version_information(event):
 
 def register(api_object, **kw):
     '''Register version information hook.'''
-
-    logger = logging.getLogger(
-        'ftrack_connect_installer_version_information:register'
-    )
 
     # Validate that api_object is an instance of ftrack_api.Session. If not,
     # assume that register is being called from an incompatible API

--- a/installers/connect-installer/setup.py
+++ b/installers/connect-installer/setup.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 '''
 requires :
@@ -59,11 +59,11 @@ AWS_PLUGIN_DOWNLOAD_PATH = (
     'https://download.ftrack.com/ftrack-connect/integrations/'
 )
 
-# Write to _version.py
+# Write out versions
 
 version_template = '''
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 __version__ = {version!r}
 '''
@@ -72,6 +72,16 @@ with open(
     os.path.join(SOURCE_PATH, 'ftrack_connect_installer', '_version.py'), 'w'
 ) as file:
     file.write(version_template.format(version=__version__))
+
+import ftrack_connect
+
+with open(
+    os.path.join(
+        SOURCE_PATH, 'ftrack_connect_installer', '_connect_version.py'
+    ),
+    'w',
+) as file:
+    file.write(version_template.format(version=ftrack_connect.__version__))
 
 print('BUILDING VERSION : {}'.format(__version__))
 
@@ -183,6 +193,12 @@ if sys.platform in ('darwin', 'win32', 'linux'):
                 SOURCE_PATH, 'ftrack_connect_installer', '_version.py'
             ),
             'resource/ftrack_connect_installer_version.py',
+        ),
+        (
+            os.path.join(
+                SOURCE_PATH, 'ftrack_connect_installer', '_connect_version.py'
+            ),
+            'resource/ftrack_connect_version.py',
         ),
         ('qt.conf', 'qt.conf'),
         ('logo.svg', 'logo.svg'),

--- a/installers/connect-installer/setup.py
+++ b/installers/connect-installer/setup.py
@@ -570,7 +570,7 @@ def post_setup(codesign_frameworks=True):
             )
 
 
-def create_dmg():
+def create_mac_dmg():
     '''Create DMG on MacOS with checksum. Returns the resulting path.'''
     dmg_name = '{0}-{1}.dmg'.format(bundle_name, __version__)
     dmg_path = os.path.join(DIST_PATH, dmg_name)
@@ -630,7 +630,7 @@ def codesign_osx(create_dmg=True, notarize=True):
     else:
         logging.info(' Application signed')
     if create_dmg:
-        dmg_path = create_dmg()
+        dmg_path = create_mac_dmg()
 
         if notarize is True:
             logging.info(' Setting up xcode, please enter your sudo password')
@@ -850,7 +850,7 @@ if sys.platform == 'darwin':
     if args.codesign:
         codesign_osx(create_dmg=args.create_dmg, notarize=args.notarize)
     elif args.create_dmg:
-        create_dmg()
+        create_mac_dmg()
 elif sys.platform == 'win32':
     if args.codesign and 'bdist_msi' in sys.argv:
         msi_name = '{0}-{1}-win64.msi'.format(bundle_name, __version__)

--- a/installers/connect-installer/source/ftrack_connect_installer/__init__.py
+++ b/installers/connect-installer/source/ftrack_connect_installer/__init__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 # from __main__ import run

--- a/installers/connect-installer/source/ftrack_connect_installer/__main__.py
+++ b/installers/connect-installer/source/ftrack_connect_installer/__main__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2023 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import logging
@@ -98,20 +98,6 @@ set_environ_default(
 
 # The httplib in python +2.7.9 requires a cacert file.
 set_environ_default('SSL_CERT_FILE', os.environ.get('REQUESTS_CA_BUNDLE'))
-
-# handle default connect and event plugin paths
-ftrack_connect_plugin_paths = [
-    os.path.abspath(os.path.join(resource_path, 'connect-standard-plugins'))
-]
-
-if 'FTRACK_CONNECT_PLUGIN_PATH' in os.environ:
-    ftrack_connect_plugin_paths.append(
-        os.environ['FTRACK_CONNECT_PLUGIN_PATH']
-    )
-
-os.environ['FTRACK_CONNECT_PLUGIN_PATH'] = os.path.pathsep.join(
-    ftrack_connect_plugin_paths
-)
 
 # handle default event plugin paths
 ftrack_event_plugin_paths = [


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

- Fix ftrack plugin path in connect installer
- Fix about dialog Connect version
- Fixed bug in about dialog were not all plugin debug informations were considered
- Allowed RV integration versioning in plugin bootstrap (YY.mmp)

## Test

Build installer and install Connect, test about dialog 