### PR TITLE
fix: Fix scaling on width on publisher

### DIFF
--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack QT library release Notes
 
+## Upcoming
+
+* [fix] asset_selector; Fix resize bug.
+
 ## V2.0.0
 2024-02-12
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -210,8 +210,9 @@ class AssetListAndInput(QtWidgets.QWidget):
     def size_changed(self):
         '''This method resizes the asset list to fit the widget, preventing
         unnecessary scrolling.'''
-        self._asset_list.setFixedSize(
-            self.size().width() - 1,
+        height = self.size().height()
+        optimal_height = (
             self._asset_list.sizeHintForRow(0) * self._asset_list.count()
-            + 2 * self._asset_list.frameWidth(),
         )
+        if height != optimal_height:
+            self._asset_list.setFixedHeight(optimal_height)


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-a61efbfa-36bc-4e4f-b9d8-795e671f535b
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

[fix] asset_selector; Fix resize bug

## Test


            