### PR TITLE
fix: PluginValidationError; Have on_fix_callback as an optional argument

### DIFF
--- a/libs/framework-core/release_notes.md
+++ b/libs/framework-core/release_notes.md
@@ -2,7 +2,9 @@
 
 ## Upcoming
 
+* [fix] PluginValidationError; Have on_fix_callback as an optional argument.
 * [fix] Engine; allow empty options in tool configs.
+
 
 ## V2.0.0
 2024-02-12

--- a/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
+++ b/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
@@ -21,7 +21,7 @@ class PluginValidationError(Exception):
     *on_fix_callback* method callback is accepted.
     """
 
-    def __init__(self, message, on_fix_callback, fix_kwargs={}):
+    def __init__(self, message, on_fix_callback=None, fix_kwargs={}):
         super(PluginValidationError, self).__init__(message)
         self.on_fix_callback = on_fix_callback
         self.fix_kwargs = fix_kwargs
@@ -30,7 +30,7 @@ class PluginValidationError(Exception):
         """
         Attempt to fix the validation error.
         """
-        if callable(self.on_fix_callback):
+        if self.on_fix_callback and callable(self.on_fix_callback):
             try:
                 self.on_fix_callback(store, **self.fix_kwargs)
                 logger.debug("Fix applied successfully.")

--- a/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
+++ b/libs/framework-core/source/ftrack_framework_core/exceptions/plugin.py
@@ -30,7 +30,7 @@ class PluginValidationError(Exception):
         """
         Attempt to fix the validation error.
         """
-        if self.on_fix_callback and callable(self.on_fix_callback):
+        if callable(self.on_fix_callback):
             try:
                 self.on_fix_callback(store, **self.fix_kwargs)
                 logger.debug("Fix applied successfully.")

--- a/projects/framework-common-extensions/tool-configs/standalone-file-opener.yaml
+++ b/projects/framework-common-extensions/tool-configs/standalone-file-opener.yaml
@@ -27,6 +27,10 @@ engine:
             - png
       - type: plugin
         tags:
+          - validator
+        plugin: file_exists_validator
+      - type: plugin
+        tags:
           - opener
         plugin: open_file
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

libs/framework-core:
- [fix] PluginValidationError; Have on_fix_callback as an optional argument

This solves issue in common extensions were PluginValidationError is called clean without the "on_fix_callback" argument, can be reproduced in for example PS when opening a file that does not exist anymore.


## Test


            