### PR TITLE
fix: Fixed bug when publishing an unsaved document causing an exception in collector

### DIFF
--- a/projects/framework-photoshop/extensions/plugins/photoshop_document_collector.py
+++ b/projects/framework-photoshop/extensions/plugins/photoshop_document_collector.py
@@ -61,8 +61,9 @@ class PhotoshopDocumentCollectorPlugin(BasePlugin):
             document_data.get('full_path') if document_data else None
         )
 
-        # Convert forward slashes to backslashes on Windows
-        document_name = os.path.normpath(document_name)
+        if document_name:
+            # Convert forward slashes to backslashes on Windows
+            document_name = os.path.normpath(document_name)
 
         try:
             extension_format = self.options['extension_format']

--- a/projects/framework-photoshop/release_notes.md
+++ b/projects/framework-photoshop/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack Framework Photoshop integration release Notes
 
+## Upcoming
+
+* [fix] Fixed bug when publishing an unsaved document causing an exception in collector.
+
 ## v24.2.0
 2024-02-13
 


### PR DESCRIPTION


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Fixed bug when publishing an unsaved document causing an exception in collector

## Test


            