### PR TITLE
fix: Fixed path bug on Windows saving .psb files

### DIFF
--- a/projects/framework-photoshop/extensions/plugins/photoshop_document_saved_validator.py
+++ b/projects/framework-photoshop/extensions/plugins/photoshop_document_saved_validator.py
@@ -31,7 +31,7 @@ class PhotoshopDocumentSavedValidatorPlugin(BasePlugin):
         self.logger.warning('Photoshop document not saved, asking to save')
         temp_path = get_temp_path(filename_extension=extension_format)
         save_result = photoshop_connection.rpc(
-            'saveDocument', [temp_path, extension_format]
+            'saveDocument', [temp_path.replace('\\', '/'), extension_format]
         )
         # Will return a boolean containing the result.
         if not save_result or isinstance(save_result, str):

--- a/projects/framework-photoshop/extensions/plugins/photoshop_save_to_temp_finalizer.py
+++ b/projects/framework-photoshop/extensions/plugins/photoshop_save_to_temp_finalizer.py
@@ -36,7 +36,7 @@ class PhotoshopSaveToTempFinalizerPlugin(BasePlugin):
 
             save_result = photoshop_connection.rpc(
                 'saveDocument',
-                [temp_path, extension_format],
+                [temp_path.replace('\\', '/'), extension_format],
             )
         except Exception as e:
             self.logger.exception(e)

--- a/projects/framework-photoshop/release_notes.md
+++ b/projects/framework-photoshop/release_notes.md
@@ -3,6 +3,7 @@
 ## v24.3.0
 2024-03-08
 
+* [fix] Fixed path bug on Windows saving .psb files.
 * [fix] Fixed bug when publishing an unsaved document causing an exception in collector.
 
 ## v24.2.0


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Fixed path bug on Windows saving .psb files

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            