### PR TITLE
fix: nuke nodegraph image exporter regression

### DIFF
--- a/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
@@ -60,19 +60,13 @@ class NukeNodegraphImageExporterPlugin(BasePlugin):
         '''
         component_name = self.options.get('component')
         try:
-            view = find_nodegraph_viewer(activate=True)
+            view = find_nodegraph_viewer()
 
         except Exception as e:
             self.logger.exception(e)
             raise PluginExecutionError(
                 f'Exception locating viewer to export: {e}'
             )
-
-        try:
-            activate_nodegraph_viewer(view)
-        except Exception as e:
-            self.logger.exception(e)
-            self.logger.warning(f'Could not active node graph viewer: {e}')
 
         try:
             image_path = get_temp_path(filename_extension='.png')


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-17ac1c87-4fe8-4723-880f-6db74ecfcb04
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Fixed a regression with Nuke nodegraph image exporter

## Test


            