### PR TITLE
fix: Fixed bug in asset_selector, if no assets on startup - properly emit asset name changed signal

### DIFF
--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -2,6 +2,8 @@
 
 ## Upcoming
 
+* [fixed] Fixed bug in asset_selector, if no assets on startup - properly emit asset name changed signal.
+* [fixed] Disabled auto scrolling on asset list. Always select the first item on activation.
 * [new] selectors/asset_selector; Change behaviour of new asset button and the name input field, list is greyed out during creation. Asset name input is hidden when an existing asset is selected. 
 
 ## v2.0.1

--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 
+* [changed] Moved OpenAssetSelector logic to AssetSelectorBase.
 * [fixed] Fixed bug in asset_selector, if no assets on startup - properly emit asset name changed signal.
 * [fixed] Disabled auto scrolling on asset list. Always select the first item on activation.
 * [new] selectors/asset_selector; Change behaviour of new asset button and the name input field, list is greyed out during creation. Asset name input is hidden when an existing asset is selected. 

--- a/libs/qt/source/ftrack_qt/widgets/frames/new_asset_input.py
+++ b/libs/qt/source/ftrack_qt/widgets/frames/new_asset_input.py
@@ -32,6 +32,7 @@ class NewAssetInput(QtWidgets.QFrame):
         self._button.setEnabled(not value)
         if value:
             self._name.setFocus()
+            self.text_changed.emit(self._name.text())
         self.active_changed.emit(value)
 
     def __init__(self, validator, placeholder_name):

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -80,12 +80,6 @@ class OpenAssetSelector(QtWidgets.QWidget):
         '''This method sets the assets in the asset list and shows or hides it
         based on the presence of assets.'''
         self._asset_list.set_assets(assets)
-        if not assets:
-            self._asset_list.hide()
-            self._new_asset_input.active = True
-        else:
-            self._asset_list.show()
-            self._new_asset_input.active = False
 
     def _on_version_changed(self, version):
         '''This method emits the version_changed signal with the given version.'''
@@ -194,6 +188,12 @@ class PublishAssetSelector(OpenAssetSelector):
 
     def set_assets(self, assets):
         super(PublishAssetSelector, self).set_assets(assets)
+        if not assets:
+            self._asset_list.hide()
+            self._new_asset_input.active = True
+        else:
+            self._asset_list.show()
+            self._new_asset_input.active = False
         # Make sure widget expands properly to fit list
         self._list_and_input.size_changed()
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -92,7 +92,9 @@ class AssetSelectorBase(QtWidgets.QWidget):
 class OpenAssetSelector(AssetSelectorBase):
     '''Asset selector tailored for open.'''
 
-    pass
+    def __init__(self):
+        '''This method initialises the open asset selector widget.'''
+        super(OpenAssetSelector, self).__init__()
 
 
 class PublishAssetSelector(AssetSelectorBase):
@@ -110,7 +112,7 @@ class PublishAssetSelector(AssetSelectorBase):
         parent=None,
     ):
         '''
-        This method initialises the asset selector widget.
+        This method initialises the publish asset selector widget.
         '''
         self._list_and_input = None
         self._new_asset_input = None

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -13,9 +13,9 @@ from ftrack_qt.widgets.frames import (
 from ftrack_qt.widgets.lists import AssetList
 
 
-class OpenAssetSelector(QtWidgets.QWidget):
-    '''This widget allows the user to select an existing asset and asset version,
-    or input an asset name for creating a new asset, depending on the mode.'''
+class AssetSelectorBase(QtWidgets.QWidget):
+
+    '''This widget allows the user to select an existing asset and asset version.'''
 
     assets_added = QtCore.Signal(object)
     '''This signal is emitted when assets are added. It sends a list of assets 
@@ -36,14 +36,12 @@ class OpenAssetSelector(QtWidgets.QWidget):
         '''
         This method initialises the asset selector widget.
         '''
-        super(OpenAssetSelector, self).__init__(parent=parent)
+        super(AssetSelectorBase, self).__init__(parent=parent)
         self.logger = logging.getLogger(
             __name__ + '.' + self.__class__.__name__
         )
 
-        self._list_and_input = None
         self._asset_list = None
-        self._new_asset_input = None
 
         self.selected_index = None
 
@@ -92,9 +90,15 @@ class OpenAssetSelector(QtWidgets.QWidget):
         self.selected_item_changed.emit(version, asset_id)
 
 
-class PublishAssetSelector(OpenAssetSelector):
-    '''This widget allows the user to select an existing asset and asset version,
-    or input an asset name for creating a new asset.'''
+class OpenAssetSelector(AssetSelectorBase):
+    '''Asset selector tailored for open.'''
+
+    pass
+
+
+class PublishAssetSelector(AssetSelectorBase):
+    '''Asset selector tailored for publish, allows user to select and existing
+    asset or input an asset name for creating a new asset.'''
 
     VALID_ASSET_NAME = QtCore.QRegExp('[A-Za-z0-9_]+')
 
@@ -109,6 +113,8 @@ class PublishAssetSelector(OpenAssetSelector):
         '''
         This method initialises the asset selector widget.
         '''
+        self._list_and_input = None
+        self._new_asset_input = None
         self.validator = QtGui.QRegExpValidator(self.VALID_ASSET_NAME)
         self.placeholder_name = "Asset Name..."
 

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -151,13 +151,13 @@ class PublishAssetSelector(AssetSelectorBase):
 
     def _on_asset_list_active_changed_callback(self, active):
         if active:
-            # Deactive new input
+            # Deactivate new input
             self._new_asset_input.active = False
 
     def _on_new_asset_active_changed_callback(self, active):
         '''This method handles changes to the new asset name input.'''
         if active:
-            # Deactive list
+            # Deactivate list
             self._asset_list.active = False
             self.selected_index = None
             self.selected_item_changed.emit(None, None)

--- a/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
+++ b/libs/qt/source/ftrack_qt/widgets/selectors/asset_selector.py
@@ -14,7 +14,6 @@ from ftrack_qt.widgets.lists import AssetList
 
 
 class AssetSelectorBase(QtWidgets.QWidget):
-
     '''This widget allows the user to select an existing asset and asset version.'''
 
     assets_added = QtCore.Signal(object)

--- a/projects/framework-common-extensions/release_notes.md
+++ b/projects/framework-common-extensions/release_notes.md
@@ -2,6 +2,5 @@
 
 ## Upcoming
 
-* [fixed] Disabled auto scrolling on asset list. Always select the first item on activation.
 * [changed] Added labels to publisher asset selector and publisher, aligned margins.
 * [new] Initial release.


### PR DESCRIPTION


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

libs/qt
[fixed] Fixed bug in asset_selector, if no assets on startup - properly emit asset name changed signal.

## Test

            