### PR TITLE
feat: Run dialog callback in Nuke main thread

### DIFF
--- a/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
+++ b/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
@@ -71,7 +71,6 @@ def get_ftrack_menu(menu_name='ftrack', submenu_name=None):
 client_instance = None
 
 
-# TODO: activate this on implementing run in main thread for nuke like in maya
 @run_in_main_thread
 def on_run_dialog_callback(dialog_name, tool_config_names, docked):
     client_instance.run_dialog(

--- a/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
+++ b/projects/framework-nuke/source/ftrack_framework_nuke/__init__.py
@@ -24,7 +24,11 @@ from ftrack_framework_core.configure_logging import configure_logging
 
 from ftrack_utils.usage import set_usage_tracker, UsageTracker
 
-from ftrack_framework_nuke.utils import dock_nuke_right, find_nodegraph_viewer
+from ftrack_framework_nuke.utils import (
+    dock_nuke_right,
+    find_nodegraph_viewer,
+    run_in_main_thread,
+)
 
 # Evaluate version and log package version
 try:
@@ -68,7 +72,7 @@ client_instance = None
 
 
 # TODO: activate this on implementing run in main thread for nuke like in maya
-# #@run_in_main_thread
+@run_in_main_thread
 def on_run_dialog_callback(dialog_name, tool_config_names, docked):
     client_instance.run_dialog(
         dialog_name,

--- a/projects/framework-nuke/source/ftrack_framework_nuke/utils/__init__.py
+++ b/projects/framework-nuke/source/ftrack_framework_nuke/utils/__init__.py
@@ -1,5 +1,7 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2024 ftrack
+from functools import wraps
+import threading
 
 from PySide2 import QtWidgets
 
@@ -55,3 +57,18 @@ def activate_nodegraph_viewer(widget):
     idx = stacked_widget.indexOf(widget)
     if stacked_widget.currentIndex() != idx:
         stacked_widget.setCurrentIndex(idx)
+
+
+def run_in_main_thread(f):
+    '''Make sure a function runs in the main Maya thread.'''
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        if threading.currentThread().name != 'MainThread':
+            return nuke.executeInMainThreadWithResult(
+                f, args=args, kwargs=kwargs
+            )
+        else:
+            return f(*args, **kwargs)
+
+    return decorated


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-2fc0468e-08c4-4b53-8d05-8320e627d8a6
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Run dialog callback in Nuke main thread

## Test

            