### PR TITLE
fix: Align extensions to not contain dot

### DIFF
--- a/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_nodegraph_image_exporter.py
@@ -69,7 +69,7 @@ class NukeNodegraphImageExporterPlugin(BasePlugin):
             )
 
         try:
-            image_path = get_temp_path(filename_extension='.png')
+            image_path = get_temp_path(filename_extension='png')
 
             self.screen_capture_widget(view, image_path)
         except Exception as e:

--- a/projects/framework-nuke/extensions/plugins/nuke_save_to_temp_finalizer.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_save_to_temp_finalizer.py
@@ -16,7 +16,7 @@ class NukeSaveToTempPlugin(BasePlugin):
 
     def run(self, store):
         '''Save to temp and store the result in the given *store*'''
-        temp_path = get_temp_path(filename_extension='.nk')
+        temp_path = get_temp_path(filename_extension='nk')
 
         self.logger.debug(f'Saving Nuke script to temp: {temp_path}')
         try:

--- a/projects/framework-nuke/extensions/plugins/nuke_script_exporter.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_exporter.py
@@ -34,7 +34,7 @@ class NukeScriptExporterPlugin(BasePlugin):
                 self.logger.debug(
                     'Exporting selection to a temp file for publish'
                 )
-                exported_path = get_temp_path(filename_extension='.nk')
+                exported_path = get_temp_path(filename_extension='nk')
 
                 self.logger.debug(
                     f'Exporting selected nodes to: {exported_path}'

--- a/projects/framework-nuke/extensions/plugins/nuke_script_saved_validator.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_script_saved_validator.py
@@ -24,7 +24,7 @@ class NukeScriptSavedValidatorPlugin(BasePlugin):
         *store*.
         '''
         try:
-            save_path = get_temp_path(filename_extension='.nk')
+            save_path = get_temp_path(filename_extension='nk')
 
             nuke.scriptSaveAs(save_path, overwrite=1)
         except Exception as error:


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-824cd33d-aa78-4a53-8721-f55dc0e9cf87
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

fix: Align extensions to not contain dot

## Test
       