### PR TITLE
fix: rename nuke_script_opener tag from importer to opener to align with m…

### DIFF
--- a/projects/framework-nuke/extensions/tool-configs/nuke-script-opener.yaml
+++ b/projects/framework-nuke/extensions/tool-configs/nuke-script-opener.yaml
@@ -25,7 +25,7 @@ engine:
           asset_type_name: script
       - type: plugin
         tags:
-          - importer
+          - opener
         plugin: nuke_script_opener
       - type: plugin
         plugin: nuke_save_to_temp_finalizer


### PR DESCRIPTION
…aya and PS


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-c82dd14a-6613-49a9-9f74-71f882583ce6
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

rename nuke_script_opener tag from importer to opener to align with maya and PS

## Test

