### PR TITLE
fix: Propagate mouse press event properly

### DIFF
--- a/libs/qt/source/ftrack_qt/widgets/asset/new_asset_input_widget.py
+++ b/libs/qt/source/ftrack_qt/widgets/asset/new_asset_input_widget.py
@@ -95,6 +95,7 @@ class NewAssetInput(QtWidgets.QFrame):
 
     def mousePressEvent(self, event):
         '''Override mouse press to emit signal.'''
+        super(NewAssetInput, self).mousePressEvent(event)
         self.active = True
         self.text_changed.emit(self._name.text())
 

--- a/libs/qt/source/ftrack_qt/widgets/lists/asset_list.py
+++ b/libs/qt/source/ftrack_qt/widgets/lists/asset_list.py
@@ -131,4 +131,5 @@ class AssetList(QtWidgets.QListWidget):
 
     def mousePressEvent(self, event):
         '''Override mouse press to emit signal.'''
+        super(AssetList, self).mousePressEvent(event)
         self.active = True

--- a/tests/framework/manual/standalone_ui_test.py
+++ b/tests/framework/manual/standalone_ui_test.py
@@ -66,7 +66,7 @@ app = QtWidgets.QApplication.instance()
 if not app:
     app = QtWidgets.QApplication(sys.argv)
 
-WHAT = 'publisher'
+WHAT = 'opener'
 client_class.run_dialog(
     dialog_name=f'framework_standard_{WHAT}_dialog',
     dialog_options={'tool_config_names': [f'standalone-file-{WHAT}']},

--- a/tests/framework/manual/standalone_ui_test.py
+++ b/tests/framework/manual/standalone_ui_test.py
@@ -66,7 +66,7 @@ app = QtWidgets.QApplication.instance()
 if not app:
     app = QtWidgets.QApplication(sys.argv)
 
-WHAT = 'opener'
+WHAT = 'publisher'
 client_class.run_dialog(
     dialog_name=f'framework_standard_{WHAT}_dialog',
     dialog_options={'tool_config_names': [f'standalone-file-{WHAT}']},


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

 Propagate mouse press event properly

## Test


            