### PR TITLE
feat: Drag-n-dropped plugins prioritized in plugin list

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [changed] Plugin manager; Drag-n-drop of a plugin ZIP overrides any existing plugins in plugin list.
+
+
 ## v3.0.0
 2024-02-16
 

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -240,6 +240,8 @@ class DndPluginList(QtWidgets.QFrame):
         return None
 
     def remove_plugin_from_list(self, plugin_name):
+        '''Remove the plugin *plugin_name* from plugin list (not disk),
+        if succeeded/found True will be returned, False otherwise.'''
         num_items = self._plugin_model.rowCount()
         for i in range(num_items):
             item = self._plugin_model.item(i)

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -239,6 +239,17 @@ class DndPluginList(QtWidgets.QFrame):
                 return item
         return None
 
+    def remove_plugin_from_list(self, plugin_name):
+        num_items = self._plugin_model.rowCount()
+        for i in range(num_items):
+            item = self._plugin_model.item(i)
+            item_name = item.data(ROLES.PLUGIN_NAME)
+            if item_name == plugin_name:
+                # Remove item
+                self._plugin_model.takeRow(i)
+                return True
+        return False
+
     def populate_installed_plugins(self, plugins):
         '''Populate model with installed plugins.'''
         self._installed_plugin_count = 0
@@ -364,7 +375,10 @@ class DndPluginList(QtWidgets.QFrame):
         paths = self._process_mime_data(event.mimeData())
 
         for path in paths:
-            self._add_plugin(get_plugin_data(path), STATUSES.NEW)
+            # Remove existing one
+            plugin_data = get_plugin_data(path)
+            self.remove_plugin_from_list(plugin_data['name'])
+            self._add_plugin(plugin_data, STATUSES.NEW)
 
         event.accept()
         self._set_drop_zone_state()

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -239,7 +239,7 @@ class DndPluginList(QtWidgets.QFrame):
                 return item
         return None
 
-    def remove_plugin_from_list(self, plugin_name):
+    def _remove_plugin(self, plugin_name):
         '''Remove the plugin *plugin_name* from plugin list (not disk),
         if succeeded/found True will be returned, False otherwise.'''
         num_items = self._plugin_model.rowCount()
@@ -379,7 +379,7 @@ class DndPluginList(QtWidgets.QFrame):
         for path in paths:
             # Remove existing one
             plugin_data = get_plugin_data(path)
-            self.remove_plugin_from_list(plugin_data['name'])
+            self._remove_plugin(plugin_data['name'])
             self._add_plugin(plugin_data, STATUSES.NEW)
 
         event.accept()


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-edaa83bf-7134-4723-8f62-3b81c520f054
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

[changed] Plugin manager; Drag-n-drop of a plugin ZIP overrides any existing plugins in plugin list

## Test

Test plugin manager