### PR TITLE
feat: Connect plugin manager filter on pre-releases

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [new] Toggle pre-releases in Plugin manager
+
+
 ## v3.0.0rc1
 2024-03-25
 

--- a/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
@@ -62,6 +62,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         '''Instantiate the plugin widget.'''
         super(PluginManager, self).__init__(session, parent=parent)
         self._label = None
+        self._select_release_type_widget = None
         self._search_bar = None
         self._plugin_list_widget = None
         self._button_layout = None
@@ -99,27 +100,12 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._label.setMargin(5)
         self.layout().addWidget(self._label)
 
+        # choose release type
+        self._select_release_type_widget = QtWidgets.QCheckBox('Pre-releases')
+        self.layout().addWidget(self._select_release_type_widget)
         # plugin list
         self._plugin_list_widget = DndPluginList()
         self.layout().addWidget(self._plugin_list_widget)
-
-        self._info_widget = QtWidgets.QFrame()
-        self._info_widget.setLayout(QtWidgets.QVBoxLayout())
-
-        self._info_widget.layout().addWidget(
-            QtWidgets.QLabel(
-                "<html><u>Plugin directory search order:</u></html>"
-            )
-        )
-        for index, plugin_directory in enumerate(PLUGIN_DIRECTORIES):
-            self._info_widget.layout().addWidget(
-                QtWidgets.QLabel(
-                    f'<html><small><code>{plugin_directory}{"</code> (target)</small></html>" if index == 0 else ""}'
-                )
-            )
-        self.layout().addWidget(self._info_widget)
-        # TODO: Display in text area with word wrap. Hide the info widget for now.
-        self._info_widget.setVisible(False)
 
         # apply and reset button.
         self._button_layout = QtWidgets.QHBoxLayout()
@@ -152,6 +138,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     def post_build(self):
         # wire connections
+        self._select_release_type_widget.clicked.connect(
+            self._on_select_release_type_callback
+        )
         self._apply_button.clicked.connect(self._on_apply_changes)
         self._reset_button.clicked.connect(self.refresh)
         self._search_bar.textChanged.connect(
@@ -239,7 +228,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         '''Callback on fetching installed plugins from Connect'''
         self._installed_plugins = plugins
         self._plugin_list_widget.populate_installed_plugins(plugins)
-        self._plugin_list_widget.populate_download_plugins()
+        self._plugin_list_widget.populate_download_plugins(
+            self._select_release_type_widget.isChecked()
+        )
         if (
             not self._initialised
             and len(self._plugin_list_widget.installed_plugins) == 0
@@ -288,6 +279,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
             self._plugin_processor.process(item)
             on_plugin_installed_callback(i + 1)
         self._reset_plugin_list()
+
+    def _on_select_release_type_callback(self):
+        self._reset_button.click()
 
     def _show_user_message_done(self):
         '''Show final message to the user.'''

--- a/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
@@ -101,7 +101,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self.layout().addWidget(self._label)
 
         # choose release type
-        self._select_release_type_widget = QtWidgets.QCheckBox('Pre-releases')
+        self._select_release_type_widget = QtWidgets.QCheckBox(
+            'Show pre-releases'
+        )
         self.layout().addWidget(self._select_release_type_widget)
         # plugin list
         self._plugin_list_widget = DndPluginList()

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -273,7 +273,7 @@ class DndPluginList(QtWidgets.QFrame):
                 )
                 logger.warning(f'Failed to add plugin {plugin}: ')
 
-    def populate_download_plugins(self):
+    def populate_download_plugins(self, prereleases=False):
         '''Populate model with remotely configured plugins.'''
         # Read plugins from json config url if set by user
         self._downloadable_plugin_count = 0
@@ -288,7 +288,7 @@ class DndPluginList(QtWidgets.QFrame):
                 self._downloadable_plugin_count += 1
         else:
             # Read latest releases from ftrack integrations repository
-            releases = fetch_github_releases()
+            releases = fetch_github_releases(prereleases=prereleases)
 
             for release in releases:
                 self._add_plugin(

--- a/apps/connect/source/ftrack_connect/utils/plugin.py
+++ b/apps/connect/source/ftrack_connect/utils/plugin.py
@@ -164,7 +164,9 @@ def fetch_github_releases(latest=True, prereleases=False):
     version of each plugin is returned. If *prereleases* is True,
     prereleases are included in the result.'''
 
-    logger.debug(f'Fetching releases from: {INTEGRATIONS_REPO}')
+    logger.debug(
+        f'Fetching releases from: {INTEGRATIONS_REPO} (pre-releases: {prereleases})'
+    )
 
     response = requests.get(f"{INTEGRATIONS_REPO}/releases")
     if response.status_code != 200:
@@ -197,7 +199,10 @@ def fetch_github_releases(latest=True, prereleases=False):
             continue
 
         if not prereleases and release.get('prerelease') is True:
-            logger.debug(f'   Skipping prerelease: {tag_name}')
+            logger.debug(f'   Skipping pre-release: {tag_name}')
+            continue
+        elif prereleases and not release.get('prerelease'):
+            logger.debug(f'   Skipping release: {tag_name}')
             continue
         release_data = {
             'id': release['id'],


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-75b8644b-c80b-4f3e-b4aa-946ce03e1a35
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes


* [new] Toggle pre-releases in Plugin manager

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            