### PR TITLE
fix: Optimized and properly using version parsing when sorting Github releases.

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [fix] Properly sort releases fetched from Github.
+
 ## v3.0.0rc2
 2024-03-26
 

--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -2,7 +2,7 @@
 
 ## Upcoming
 
-* [fix] Properly sort releases fetched from Github.
+* [fix] Optimized and properly using version parsing when sorting Github releases.
 
 ## v3.0.0rc2
 2024-03-26

--- a/apps/connect/source/ftrack_connect/utils/plugin.py
+++ b/apps/connect/source/ftrack_connect/utils/plugin.py
@@ -173,7 +173,7 @@ def fetch_github_releases(latest=True, prereleases=False):
         logger.error(f'Failed to fetch releases from {INTEGRATIONS_REPO}')
         return []
 
-    data = []
+    data = {}
 
     # Expect list of releases
     for release in response.json():
@@ -249,23 +249,24 @@ def fetch_github_releases(latest=True, prereleases=False):
         if url:
             logger.debug(f'Supplying release: {tag_name}')
             release_data['url'] = url
-            data.append(release_data)
+            if latest:
+                # Sort later
+                if package not in data:
+                    data[package] = {}
+                data[package][version] = release_data
+            else:
+                data[package] = release_data
 
-    if latest:
-        # Only provide the latest version
+    import json
 
-        data.sort(key=lambda x: x['tag'], reverse=True)
-
-        result = []
-        for item in data:
-            if (
-                not result
-                or item['tag'].rsplit('/', 1)[0]
-                != result[-1]['tag'].rsplit('/', 1)[0]
-            ):
-                result.append(item)
-    else:
-        result = data
+    result = []
+    for package in list(data.keys()):
+        if latest:
+            # Only provide the latest version
+            target_version = sorted(list(data[package].keys()))[-1]
+        else:
+            target_version = data[package]
+        result.append(data[package][target_version])
 
     return result
 

--- a/apps/connect/source/ftrack_connect/utils/plugin.py
+++ b/apps/connect/source/ftrack_connect/utils/plugin.py
@@ -249,24 +249,17 @@ def fetch_github_releases(latest=True, prereleases=False):
         if url:
             logger.debug(f'Supplying release: {tag_name}')
             release_data['url'] = url
-            if latest:
-                # Sort later
-                if package not in data:
-                    data[package] = {}
-                data[package][version] = release_data
-            else:
+            if not latest or package not in data:
                 data[package] = release_data
-
-    import json
+            else:
+                current_version = data[package]['tag'].rsplit('/', 1)[1][1:]
+                if parse(current_version) < parse(version):
+                    # This version is higher
+                    data[package] = release_data
 
     result = []
-    for package in list(data.keys()):
-        if latest:
-            # Only provide the latest version
-            target_version = sorted(list(data[package].keys()))[-1]
-        else:
-            target_version = data[package]
-        result.append(data[package][target_version])
+    for release in list(data.values()):
+        result.append(release)
 
     return result
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

Properly sort releases fetched from Github - the previous implementation relied on releases being reported back in correct order from Github.

## Test
