### PR TITLE
fix: Writeable node validator, show all nodes in node selector - not only selected, for user choice

### DIFF
--- a/projects/framework-nuke/extensions/plugins/nuke_node_collector.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_node_collector.py
@@ -11,14 +11,18 @@ class NukeNodeCollectorPlugin(BasePlugin):
 
     def ui_hook(self, payload):
         '''
-        Return all available write nodes in Nuke
+        Return all available nodes in the current nuke script.
         '''
-        selected_nodes = nuke.selectedNodes()
-        if len(selected_nodes) == 0:
-            selected_nodes = nuke.allNodes()
         node_names = []
-        for node in selected_nodes:
+        for node in nuke.allNodes():
             node_names.append(node.name())
+        selected_nodes = nuke.selectedNodes()
+        if len(selected_nodes) > 0:
+            selected_node = selected_nodes[0].name()
+            # Remove and add the selected node to the top of the list, so
+            # user still can select among all nodes
+            node_names.remove(selected_node)
+            node_names.insert(0, selected_node)
         return node_names
 
     def run(self, store):

--- a/projects/framework-nuke/extensions/plugins/nuke_writeable_node_validator.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_writeable_node_validator.py
@@ -1,0 +1,50 @@
+# :coding: utf-8
+# :copyright: Copyright (c) 2024 ftrack
+
+import nuke
+
+from ftrack_framework_core.plugin import BasePlugin
+from ftrack_framework_core.exceptions.plugin import PluginValidationError
+
+
+class NukeWriteableNodeValidatorPlugin(BasePlugin):
+    '''
+    Plugin to validate if a nuke node exists.
+    '''
+
+    name = 'nuke_writeable_node_validator'
+
+    def clean_selection(self):
+        '''Clean the current selection in Nuke.'''
+        for node in nuke.selectedNodes():
+            node['selected'].setValue(False)
+
+    def run(self, store):
+        '''
+        Check node exists.
+        '''
+        component_name = self.options.get('component', 'main')
+        node_name = store['components'][component_name].get('node_name')
+
+        node = nuke.toNode(node_name)
+        selected_nodes = nuke.selectedNodes()
+        self.clean_selection()
+
+        write_node = nuke.createNode('Write')
+        try:
+            if not write_node.setInput(0, node):
+                raise PluginValidationError(
+                    "The selected node can't be connected"
+                    f" to a write node: {node_name}"
+                )
+        finally:
+            # delete temporary write node
+            nuke.delete(write_node)
+
+            # restore selection
+            self.clean_selection()
+            for node in selected_nodes:
+                node['selected'].setValue(True)
+
+        self.logger.debug(f'Node "{node_name}" exists.')
+        store['components'][component_name]['valid_node'] = True

--- a/projects/framework-nuke/extensions/plugins/nuke_writeable_node_validator.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_writeable_node_validator.py
@@ -9,7 +9,7 @@ from ftrack_framework_core.exceptions.plugin import PluginValidationError
 
 class NukeWriteableNodeValidatorPlugin(BasePlugin):
     '''
-    Plugin to validate if a nuke node exists.
+    Plugin to validate if the collected Nuke node can be connected to a write node.
     '''
 
     name = 'nuke_writeable_node_validator'
@@ -21,7 +21,7 @@ class NukeWriteableNodeValidatorPlugin(BasePlugin):
 
     def run(self, store):
         '''
-        Check node exists.
+        Check node writeable
         '''
         component_name = self.options.get('component', 'main')
         node_name = store['components'][component_name].get('node_name')

--- a/projects/framework-nuke/extensions/tool-configs/nuke-script-publisher.yaml
+++ b/projects/framework-nuke/extensions/tool-configs/nuke-script-publisher.yaml
@@ -61,6 +61,10 @@ engine:
         ui: validator_label
       - type: plugin
         tags:
+          - validator
+        plugin: nuke_writeable_node_validator
+      - type: plugin
+        tags:
           - exporter
         plugin: nuke_render_exporter
 

--- a/projects/framework-nuke/release_notes.md
+++ b/projects/framework-nuke/release_notes.md
@@ -1,9 +1,16 @@
 # ftrack Framework Nuke integration release Notes
 
+## Upcoming
+
+* [changed] When selecting the node to render for reviewable, show all nodes with the selected one on top.
+* [new] Writeable node validator, to check if a node is writeable for a reviewable to be created.
+
+
 ## 24.3.0rc2
 2024-03-26
 
 * [changed] Upgrade ftrack-framework-core, ftrack-utils and ftrack-qt version.
+
 
 ## v24.3.0rc1
 2024-03-25

--- a/projects/framework-nuke/release_notes.md
+++ b/projects/framework-nuke/release_notes.md
@@ -1,6 +1,7 @@
 # ftrack Framework Nuke integration release Notes
 
-## Upcoming
+## 24.3.0rc3
+2024-03-28
 
 * [changed] When selecting the node to render for reviewable, show all nodes with the selected one on top.
 * [new] Writeable node validator, to check if a node is writeable for a reviewable to be created.


### PR DESCRIPTION
… reviewable to be created.[changed] When selecting the node to render for reviewable, show all nodes with the selected one on top.


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-bb89fdd3-b703-4c70-8a1a-6d0001f98182
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

* [changed] When selecting the node to render for reviewable, show all nodes with the selected one on top.
* [new] Writeable node validator, to check if a node is writeable for a reviewable to be created.


## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            