### PR TITLE
fix: Align cookiecutter template with latest framework changes

### DIFF
--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/__version__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/__version__.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 __version__ = '{{ cookiecutter.version }}'

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/hook/discover_ftrack_framework_{{cookiecutter.integration_name}}.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/hook/discover_ftrack_framework_{{cookiecutter.integration_name}}.py
@@ -1,12 +1,12 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import os
 import ftrack_api
 import logging
 import functools
 
-from ftrack_connect.util import get_connect_plugin_version
+from ftrack_utils.version import get_connect_plugin_version
 
 # The name of the integration, should match name in launcher.
 NAME = 'framework-{{ cookiecutter.integration_name }}'

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/launch/{{ cookiecutter.integration_name }}-launch.yaml
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/launch/{{ cookiecutter.integration_name }}-launch.yaml
@@ -1,4 +1,4 @@
-type: launcher
+type: launch_config
 name: framework-{{ cookiecutter.integration_name }}
 priority: 100
 context:

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_save_to_temp_finalizer.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_save_to_temp_finalizer.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_utils.paths import get_temp_path
 from ftrack_framework_core.plugin import BasePlugin

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_collector.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_collector.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 from ftrack_framework_core.exceptions.plugin import PluginExecutionError

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_exporter.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_exporter.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_utils.paths import get_temp_path
 

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 from ftrack_framework_core.plugin import BasePlugin
 from ftrack_framework_core.exceptions.plugin import PluginExecutionError

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/requirements.txt
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/requirements.txt
@@ -1,4 +1,0 @@
-ftrack_qt == "2.0.0rc1"
-ftrack-constants == "2.0.0rc1"
-ftrack_framework_{{ cookiecutter.integration_name }} == "2.0.0rc1"
-ftrack_utils == "2.0.0rc1"

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/{{ cookiecutter.integration_name }}.yaml
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/{{ cookiecutter.integration_name }}.yaml
@@ -8,6 +8,7 @@ tools:
     options:
       tool_configs:
         - {{ cookiecutter.integration_name }}-scene-publisher
+      docked: true
   - name: open
     label: "Open"
     dialog_name: framework_standard_opener_dialog
@@ -15,3 +16,4 @@ tools:
     options:
       tool_configs:
         - {{ cookiecutter.integration_name }}-scene-opener
+      docked: false

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/pyproject.toml
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/pyproject.toml
@@ -10,27 +10,32 @@ homepage = "https://ftrack.com"
 repository = "https://github.com/ftrackhq/integrations/tree/main/projects/framework-{{cookiecutter.integration_name }}"
 
 [[tool.poetry.source]]
+name = "PyPI"
+priority = "primary"
+
+[[tool.poetry.source]]
 name = "testpypi"
 url = "https://test.pypi.org/simple/"
-default = false
-secondary = false
+priority = "explicit"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
+python = ">= 3.7, < 3.9"
 ftrack-python-api = "^2.5.4"
-# ftrack dependencies
-ftrack-constants = { version = "> 1, < 3", optional = true }
-ftrack-utils = { version = "> 1, < 3", optional = true }
+#ftrack
+ftrack-constants = {  version = "^2.0.0", optional = true }
+ftrack-utils = {  version = "^2.0.0", optional = true }
 # framework dependencies
-ftrack-framework-core = { version = "> 1, < 3", optional = true }
-ftrack-framework-qt = { version = "> 1, < 3", optional = true }
-ftrack-qt = { version = "> 1, < 3", optional = true }
+ftrack-framework-core = {  version = "^2.0.0", optional = true }
+ftrack-framework-qt = {  version = "^2.0.0", optional = true }
+ftrack-qt = { version = "^2.0.0", optional = true }
+ftrack-qt-style = { version = "^2.0.0", optional = true }
 
 [tool.poetry.extras]
-ftrack-libs = ["ftrack-constants", "ftrack-utils", "ftrack-qt"]
+ftrack-libs = ["ftrack-constants", "ftrack-utils", "ftrack-qt", "ftrack-qt-style"]
 framework-libs = ["ftrack-framework-core", "ftrack-framework-qt"]
 
 [tool.poetry.group.documentation]

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/resource/bootstrap/init.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/resource/bootstrap/init.py
@@ -1,4 +1,4 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 
 import {{ cookiecutter.package_name }}

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/__init__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/__init__.py
@@ -1,8 +1,9 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import logging
 import os
 import traceback
+import platform
 
 import ftrack_api
 
@@ -17,6 +18,8 @@ from ftrack_constants import framework as constants
 from ftrack_utils.extensions.environment import (
     get_extensions_path_from_environment,
 )
+
+from ftrack_utils.usage import set_usage_tracker, UsageTracker
 
 from ftrack_framework_{{ cookiecutter.integration_name }}.utils import dock_{{ cookiecutter.integration_name }}_right, run_in_main_thread
 
@@ -44,11 +47,14 @@ logger.debug('v{}'.format(__version__))
 
 @run_in_main_thread
 def on_run_dialog_callback(
-    client_instance, dialog_name, tool_config_names, {{ cookiecutter.integration_name }}_args
+    client_instance, dialog_name, tool_config_names, docked, {{ cookiecutter.integration_name }}_args
 ):
     client_instance.run_dialog(
         dialog_name,
-        dialog_options={'tool_config_names': tool_config_names},
+        dialog_options={
+            'tool_config_names': tool_config_names,
+            'docked': docked,
+        },
         dock_func=dock_{{ cookiecutter.integration_name }}_right,
     )
 
@@ -70,6 +76,48 @@ def bootstrap_integration(framework_extensions_path):
     # Instantiate registry
     registry_instance = Registry()
     registry_instance.scan_extensions(paths=framework_extensions_path)
+
+    registry_info_dict = {
+        'tool_configs': [
+            item['name'] for item in registry_instance.tool_configs
+        ]
+        if registry_instance.tool_configs
+        else [],
+        'plugins': [item['name'] for item in registry_instance.plugins]
+        if registry_instance.plugins
+        else [],
+        'engines': [item['name'] for item in registry_instance.engines]
+        if registry_instance.engines
+        else [],
+        'widgets': [item['name'] for item in registry_instance.widgets]
+        if registry_instance.widgets
+        else [],
+        'dialogs': [item['name'] for item in registry_instance.dialogs]
+        if registry_instance.dialogs
+        else [],
+        'launch_configs': [
+            item['name'] for item in registry_instance.launch_configs
+        ]
+        if registry_instance.launch_configs
+        else [],
+        'dcc_configs': [item['name'] for item in registry_instance.dcc_configs]
+        if registry_instance.dcc_configs
+        else [],
+    }
+
+    # Set mix panel event
+    set_usage_tracker(
+        UsageTracker(
+            session=session,
+            default_data=dict(
+                app="{{ cookiecutter.integration_name.capitalize() }}",
+                registry=registry_info_dict,
+                version=__version__,
+                app_version=get_dcc_version(),
+                os=platform.platform(),
+            ),
+        )
+    )
 
     # Instantiate Host and Client
     Host(event_manager, registry=registry_instance)

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/utils/__init__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/utils/__init__.py
@@ -1,5 +1,5 @@
 # :coding: utf-8
-# :copyright: Copyright (c) 2014-2024 ftrack
+# :copyright: Copyright (c) 2024 ftrack
 import threading
 
 # Dock widget in {{ cookiecutter.integration_name.capitalize() }}


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

<!--
  What are you changing and what is the reason? If there are any UI changes, include a screenshot for the changes.
-->

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            