### PR TITLE
fix: Fix cookiecutter from Houdini and Unreal bugs found

### DIFF
--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/README.md
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/README.md
@@ -67,21 +67,6 @@ to build the plugin.
 To build from source, not involving PyPi, use the `--from_source` flag.
 
 
-### Build documentation
-
-
-Install documentation dependencies:
-
-```bash
-    poetry install --only documentation
-```
-
-Build documentation:
-
-```bash
-    poetry run sphinx-build -b html doc dist/doc
-```
-
 ## Installing
 
 ### Connect plugin

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/README.md
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/README.md
@@ -9,15 +9,17 @@ Community owned {{ cookiecutter.integration_name.capitalize() }} integration for
 ### Preparations
 
 
-Install Poetry
+1. Install Poetry
 
-Create a Python >=3.7, <3.12 virtual environment. If you're using an Apple Silicon chip, follow the instructions in the [How to install compatible PySide2 on Silicon based Mac](../../README.md#how-to-install-compatible-pyside2-on-silicon-based-mac) section. 
+2. Create a Python 3.7 virtual environment. If you're using an Apple Silicon chip, follow the instructions in the [How to install compatible PySide2 on Silicon based Mac](../../README.md#how-to-install-compatible-pyside2-on-silicon-based-mac) section. 
 
-Activate the virtual environment. 
+3. Activate the virtual environment. 
 
-Update release notes.
+4. If any dependent libraries updated, make sure to release them to PyPi prior to building the plugin.
 
-Set or bump version in pyproject.toml:
+5. Update release notes.
+
+6. Set or bump version in pyproject.toml:
 
 ```bash
     poetry version prerelease
@@ -35,9 +37,9 @@ or:
     poetry version major
 ```
 
-Bump the connect plugin version in integrations/projects/framework-{{ cookiecutter.integration_name }}/connect-plugin/__version__.py
+7. Bump the connect plugin version in integrations/projects/framework-{{ cookiecutter.integration_name }}/connect-plugin/__version__.py
 
-Tag and push to SCM
+8. Tag and push to SCM
 
 
 ### CI build

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/__version__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/connect-plugin/__version__.py
@@ -1,4 +1,0 @@
-# :coding: utf-8
-# :copyright: Copyright (c) 2024 ftrack
-
-__version__ = '{{ cookiecutter.version }}'

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/pyproject.toml
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/pyproject.toml
@@ -24,25 +24,19 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
 python = ">= 3.7, < 3.9"
-ftrack-python-api = "^2.5.4"
 #ftrack
+ftrack-python-api = "^2.5.4"
 ftrack-constants = {  version = "^2.0.0", optional = true }
 ftrack-utils = {  version = "^2.0.0", optional = true }
+ftrack-qt = { version = "^2.0.0", optional = true }
+ftrack-qt-style = { version = "^2.0.0", optional = true }
 # framework dependencies
 ftrack-framework-core = {  version = "^2.0.0", optional = true }
 ftrack-framework-qt = {  version = "^2.0.0", optional = true }
-ftrack-qt = { version = "^2.0.0", optional = true }
-ftrack-qt-style = { version = "^2.0.0", optional = true }
 
 [tool.poetry.extras]
 ftrack-libs = ["ftrack-constants", "ftrack-utils", "ftrack-qt", "ftrack-qt-style"]
 framework-libs = ["ftrack-framework-core", "ftrack-framework-qt"]
-
-[tool.poetry.group.documentation]
-optional = true
-
-[tool.poetry.group.documentation.dependencies]
-markdown = "<=3.2.2"
 
 [tool.black]
 line-length = 79

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/__init__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/__init__.py
@@ -113,7 +113,7 @@ def bootstrap_integration(framework_extensions_path):
                 app="{{ cookiecutter.integration_name.capitalize() }}",
                 registry=registry_info_dict,
                 version=__version__,
-                app_version=get_dcc_version(),
+                app_version="2024", # TODO: fetch DCC version through API
                 os=platform.platform(),
             ),
         )

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/utils/__init__.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/source/{{ cookiecutter.package_name }}/utils/__init__.py
@@ -1,9 +1,10 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2024 ftrack
 import threading
+from functools import wraps
 
 # Dock widget in {{ cookiecutter.integration_name.capitalize() }}
-def dock_{{ cookiecutter.integration_name.capitalize() }}_right(widget):
+def dock_{{ cookiecutter.integration_name }}_right(widget):
     '''Dock *widget* to the right side of {{ cookiecutter.integration_name.capitalize() }}.'''
     pass
 


### PR DESCRIPTION
… Fix init get dcc version; Fixed dock_<dcc>right util; Fixed util missing wraps import


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes


- Remove doc build from README and toml
- Restructured toml ftrack deps
- Fix init get dcc version
- Fixed dock_<dcc>right util
- Fixed util missing wraps import
- Removed connect-plugin/__version__.py


## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            