### PR TITLE
fix: Update CI to use intel mac instead of new default M1

### DIFF
--- a/.github/workflows/build-connect.yml
+++ b/.github/workflows/build-connect.yml
@@ -183,7 +183,7 @@ jobs:
   installer-macos:
     name: Build Connect Installer on MacOs
     needs: [ set-variables, connect-build ]
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       CODESIGN: 'True' # Set this to 'True' or 'False' as needed
     steps:

--- a/installers/connect-installer/setup.py
+++ b/installers/connect-installer/setup.py
@@ -22,7 +22,7 @@ import re
 
 # The Connect installer version, remember to bump this and update release notes
 # prior to release
-__version__ = '24.4.1rc2'
+__version__ = '24.4.1rc1'
 
 # Embedded plugins.
 

--- a/installers/connect-installer/setup.py
+++ b/installers/connect-installer/setup.py
@@ -22,7 +22,7 @@ import re
 
 # The Connect installer version, remember to bump this and update release notes
 # prior to release
-__version__ = '24.4.1rc1'
+__version__ = '24.4.1rc2'
 
 # Embedded plugins.
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

connect ci/cd
- Update CI to use intel mac instead of new default M1

## Test

<!--
  How should this be tested? Include any requirements on other repositories or environment.
  For bug fixes, include the original reproduction steps.
-->
            