### PR TITLE
fix: Nuke launcher; Properly escaped version expressions.

### DIFF
--- a/projects/framework-nuke/extensions/launch/nuke-launch.yaml
+++ b/projects/framework-nuke/extensions/launch/nuke-launch.yaml
@@ -20,7 +20,7 @@ search_path:
       - Nuke.*
     expression:
       - Nuke\d.+
-    version_expression: Nuke(?P<version>.*)\/.+$
+    version_expression: "Nuke(?P<version>.*)\/.+$"
   windows:
     prefix:
       - C:\
@@ -28,7 +28,7 @@ search_path:
     expression:
       - Nuke.*
       - Nuke\d.+.exe
-    version_expression: (?P<version>[\\d.]+[vabc]+[\\dvabc.]*)"
+    version_expression: "(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)"
   darwin:
     prefix:
       - "/"

--- a/projects/framework-nuke/extensions/launch/nukex-launch.yaml
+++ b/projects/framework-nuke/extensions/launch/nukex-launch.yaml
@@ -20,7 +20,7 @@ search_path:
       - Nuke.*
     expression:
       - Nuke\d.+
-    version_expression: Nuke(?P<version>.*)\/.+$
+    version_expression: "Nuke(?P<version>.*)\/.+$"
     launch_arguments:
       - "--nukex"
   windows:
@@ -30,7 +30,7 @@ search_path:
     expression:
       - Nuke.*
       - Nuke\d.+.exe
-    version_expression: (?P<version>[\\d.]+[vabc]+[\\dvabc.]*)
+    version_expression: "(?P<version>[\\d.]+[vabc]+[\\dvabc.]*)"
     launch_arguments:
       - "--nukex"
   darwin:

--- a/projects/framework-nuke/release_notes.md
+++ b/projects/framework-nuke/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack Framework Nuke integration release Notes
 
+## Upcoming
+
+* [fix] Launcher; Properly escaped version expressions.
+
 ## v24.4.0
 2024-04-02
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

framework-nuke
-  Nuke launcher; Properly escaped version expressions.

## Test

Test on Windows