### PR TITLE
fix: Core::Registry; Prevent crash if no extensions.

### DIFF
--- a/libs/framework-core/pyproject.toml
+++ b/libs/framework-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-framework-core"
-version = "2.2.0"
+version = "2.2.1"
 description='ftrack Framework Core library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/framework-core/release_notes.md
+++ b/libs/framework-core/release_notes.md
@@ -1,9 +1,16 @@
 # ftrack Framework Core library release Notes
 
+## v2.2.1
+2024-05-06
+
+* [fix] Registry; Prevent crash if no extensions.
+
+
 ## v2.2.0
 2024-05-02
 
 * [fix] Registry; Correctly registering unique objects.
+
 
 ## v2.1.0
 2024-04-02
@@ -12,6 +19,7 @@
 * [changed] Registry; registry.scan_extensions now support merging of YAML configs, and ignoring (+restoring) duplicate Python extensions(engin, plugin, widget, dialog)
 * [fix] launchers config yaml files type value renamed from launchers to launch_config to align to the rest of config files.
 * [fix] Fix error on sending mix panel event when run_dialog passing the non serializable docked_func
+
 
 ## v2.0.1
 2024-03-08

--- a/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/registry/__init__.py
@@ -99,6 +99,7 @@ class Registry(object):
         Scan framework extension modules from the given *paths*. If *extension_types*
         is given, only consider the given extension types.
         '''
+        unique_extensions = []
 
         discovered_extensions = []
         for path in reversed(paths):


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

_framework-core:_
- [fix] Registry; Prevent crash if no extensions.

## Test
