### PR TITLE
feat: Surpress standalone icon on windows

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack Connect release Notes
 
+## upcoming
+
+* [changed] Prevent additional icon for standalone process to appear on windows.
+
 
 ## 24.5.0
 2024-05-07

--- a/apps/connect/source/ftrack_connect/application_launcher/__init__.py
+++ b/apps/connect/source/ftrack_connect/application_launcher/__init__.py
@@ -778,6 +778,11 @@ class ApplicationLauncher(object):
                     options["creationflags"] = subprocess.CREATE_NO_WINDOW
                     options["shell"] = True
 
+                startupinfo = subprocess.STARTUPINFO()
+                startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+                options['startupinfo'] = startupinfo
+
                 try:
                     process = subprocess.Popen(command, **options)
                 except (OSError, TypeError):


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [X] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

_apps/connect:_

- [changed] Prevent additional icon for standalone process to appear on windows.

## Test

Launch PS, not extra icon should appear in taskbar.
            