### PR TITLE
fix: Make cookiecutter plugins runnable OOTB

### DIFF
--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_save_to_temp_finalizer.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_save_to_temp_finalizer.py
@@ -14,7 +14,7 @@ class {{ cookiecutter.integration_name.capitalize() }}SaveToTempPlugin(BasePlugi
         Makes sure that the current opened scene is saved to a temp file so
         prevents it to be overriden.
         '''
-        # scene_type = '.mb'
+        scene_type = '.mb'
 
         try:
             # Save file to a temp file

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_collector.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_collector.py
@@ -14,14 +14,18 @@ class {{ cookiecutter.integration_name.capitalize() }}SceneCollectorPlugin(BaseP
         extension format to be published to the *store*. Also collect the
         scene_name and collect if scene is saved.
         '''
+        scene_name = None
+        scene_saved = False
         try:
             # TODO: get scene name from DCC
+            pass
         except Exception as error:
             raise PluginExecutionError(
                 f"Error retrieving the scene name: {error}"
             )
         try:
             # TODO: check if DCC scene is saved
+            pass
         except Exception as error:
             raise PluginExecutionError(
                 f"Error Checking if the scene is saved: {error}"

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_exporter.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_exporter.py
@@ -19,12 +19,14 @@ class {{ cookiecutter.integration_name.capitalize() }}SceneExporterPlugin(BasePl
         component_name = self.options.get('component')
 
         export_type = store['components'][component_name].get('export_type')
-
         scene_name = store['components'][component_name].get('scene_name')
+
+        exported_path = None
 
         if export_type == 'selection':
             try:
-               # TODO: Export selected objects
+                # TODO: Export selected objects
+                pass
             except Exception as error:
                 raise PluginExecutionError(
                     message=f"Couldn't export selection, error:{error}"

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
@@ -25,6 +25,7 @@ class {{ cookiecutter.integration_name.capitalize() }}SceneOpenerPlugin(BasePlug
 
         try:
             # TODO: Open file in DCC
+            pass
         except Exception as error:
             raise PluginExecutionError(
                 f"Couldn't open the given path. Error: {error}"

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_saved_validator.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_saved_validator.py
@@ -61,13 +61,15 @@ class {{ cookiecutter.integration_name.capitalize() }}SceneSavedValidatorPlugin(
         scene_name = store['components'][component_name].get('scene_name')
         scene_saved = store['components'][component_name].get('scene_saved')
 
+        extension_format = '<format>'
+
         if not scene_name:
             # Scene is not saved, save it first.
             self.logger.warning('{{ cookiecutter.integration_name.capitalize() }} scene has never been saved.')
             raise PluginValidationError(
                 message='{{ cookiecutter.integration_name.capitalize() }} scene has never been saved, Click fix to save it to a temp file',
                 on_fix_callback=self.save_to_temp,
-                fix_kwargs={'extension_format': <Your file type>},
+                fix_kwargs={'extension_format': extension_format},
             )
         if not scene_saved:
             self.logger.warning('{{ cookiecutter.integration_name.capitalize() }} scene not saved')

--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_thumbnail_exporter.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_thumbnail_exporter.py
@@ -18,6 +18,7 @@ class {{ cookiecutter.integration_name.capitalize() }}ThumbnailExporterPlugin(Ba
         '''
         component_name = self.options.get('component')
 
+        thumbnail_path = None
         try:
             # TODO: thumbnail_path = Export thumbnail
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

cookiecutter-framework:

- Make cookiecutter plugins runnable OOTB

## Test


            