### PR TITLE
feat: Possibility to disable the plugin manager by setting environment variable FTRACK_DISABLE_PLUGIN_MANAGER to true

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## upcoming
+
+* [new] Possibility to disable the plugin manager by setting environment variable FTRACK_DISABLE_PLUGIN_MANAGER to true.
+
+
 ## 24.5.1
 2024-05-13
 

--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -711,7 +711,11 @@ class Application(QtWidgets.QMainWindow):
 
         self._configure_action_launcher_widget()  # Was external ftrack-connect action-launcher plugin
 
-        self._configure_plugin_manager_widget()  # Was external ftrack-connect-plugin-manager plugin
+        if (os.environ.get('FTRACK_DISABLE_PLUGIN_MANAGER') or '') not in [
+            'true',
+            '1',
+        ]:
+            self._configure_plugin_manager_widget()  # Was external ftrack-connect-plugin-manager plugin
 
         self._discover_connect_widgets()
 


### PR DESCRIPTION


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

_apps/connect:_

- t variable FTRACK_DISABLE_PLUGIN_MANAGER to true


## Test
