### PR TITLE
feat: Set or disable Github releases URL 

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## upcoming
+
+* [new] Ability to set the default URL for downloading releases from Github in the plugin manager, by setting the environment variable FTRACK_CONNECT_GITHUB_RELEASES_URL. Also supports disabling fetch by setting it to 'none'.
+
+
 ## 24.5.1
 2024-05-13
 

--- a/apps/connect/source/ftrack_connect/__init__.py
+++ b/apps/connect/source/ftrack_connect/__init__.py
@@ -88,7 +88,9 @@ DEPRECATED_PLUGINS = [
 ]
 
 # ftrack integrations repo URL from were to discover and download plugins
-INTEGRATIONS_REPO = 'https://api.github.com/repos/ftrackhq/integrations'
+DEFAULT_INTEGRATIONS_REPO_URL = (
+    'https://api.github.com/repos/ftrackhq/integrations'
+)
 
 
 def load_icons(font_folder):

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -302,7 +302,7 @@ class DndPluginList(QtWidgets.QFrame):
                 )
                 return
             # Read latest releases from ftrack integrations repository
-            releases = fetch_github_releases(prereleases=prereleases)
+            releases = fetch_github_releases(url, prereleases=prereleases)
 
             for release in releases:
                 self._add_plugin(

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -10,6 +10,7 @@ import shutil
 import logging
 import qtawesome as qta
 
+from ftrack_connect import DEFAULT_INTEGRATIONS_REPO_URL
 
 try:
     from PySide6 import QtWidgets, QtCore, QtGui
@@ -290,6 +291,16 @@ class DndPluginList(QtWidgets.QFrame):
                 self._add_plugin(get_plugin_data(link), STATUSES.DOWNLOAD)
                 self._downloadable_plugin_count += 1
         else:
+            url = os.environ.get(
+                'FTRACK_CONNECT_GITHUB_RELEASES_URL',
+                DEFAULT_INTEGRATIONS_REPO_URL,
+            )
+            if url.lower() in ['none', 'disable', '0', 'false']:
+                logger.warning(
+                    'Not attempting to fetch releases from Github, '
+                    'disabled by environment variable.'
+                )
+                return
             # Read latest releases from ftrack integrations repository
             releases = fetch_github_releases(prereleases=prereleases)
 

--- a/apps/connect/source/ftrack_connect/utils/plugin.py
+++ b/apps/connect/source/ftrack_connect/utils/plugin.py
@@ -12,7 +12,6 @@ import platformdirs
 from packaging.version import parse
 from packaging.specifiers import SpecifierSet
 
-from ftrack_connect import INTEGRATIONS_REPO
 
 from ftrack_connect import (
     INCOMPATIBLE_PLUGINS,
@@ -217,19 +216,19 @@ def check_major_version(version, major_version_start=24):
         return False
 
 
-def fetch_github_releases(latest=True, prereleases=False):
+def fetch_github_releases(url, latest=True, prereleases=False):
     '''Read github releases and return a list of releases, and
     list of assets as value. If *latest* is True, only the latest
     version of each plugin is returned. If *prereleases* is True,
     prereleases are included in the result.'''
 
     logger.debug(
-        f'Fetching releases from: {INTEGRATIONS_REPO} (pre-releases: {prereleases})'
+        f'Fetching releases from: {url} (pre-releases: {prereleases})'
     )
 
-    response = requests.get(f"{INTEGRATIONS_REPO}/releases")
+    response = requests.get(f"{url}/releases")
     if response.status_code != 200:
-        logger.error(f'Failed to fetch releases from {INTEGRATIONS_REPO}')
+        logger.error(f'Failed to fetch releases from {url}')
         return []
 
     data = {}


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

_apps/connect:_
- [new] Ability to set the default URL for downloading releases from Github in the plugin manager, by setting the environment variable FTRACK_CONNECT_GITHUB_RELEASES_URL. Also supports disabling fetch by setting it to 'none'.

## Test

            