### PR TITLE
fix: open component does not get discovered

### DIFF
--- a/apps/connect/source/ftrack_connect/hook/open_component_directory.py
+++ b/apps/connect/source/ftrack_connect/hook/open_component_directory.py
@@ -111,8 +111,7 @@ class OpenComponentDirectoryAction(object):
         '''Register to event hub.'''
         self.session.event_hub.subscribe(
             u'topic=ftrack.action.discover and '
-            u'source.user.username="{0}" and '
-            u'data.host={1}'.format(self.session.api_user, self.node),
+            u'source.user.username="{0}" and '.format(self.session.api_user),
             self.discover,
         )
 


### PR DESCRIPTION
removed the host from discovery as is not been added yet at that stage, it gets added during the discovery to target the machine which runs it.