### PR TITLE
fix: Backlog/fix dialog bug if no tool config

### DIFF
--- a/projects/framework-common-extensions/dialogs/standard_loader_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_loader_dialog.py
@@ -285,6 +285,7 @@ class StandardLoaderDialog(BaseDialog):
 
     def closeEvent(self, event):
         '''(Override) Close the context and progress widgets'''
-        self._progress_widget.teardown()
-        self._progress_widget.deleteLater()
+        if self._progress_widget:
+            self._progress_widget.teardown()
+            self._progress_widget.deleteLater()
         super(StandardLoaderDialog, self).closeEvent(event)

--- a/projects/framework-common-extensions/dialogs/standard_loader_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_loader_dialog.py
@@ -202,6 +202,7 @@ class StandardLoaderDialog(BaseDialog):
                 "font-style: italic; font-weight: bold; color: red;"
             )
             self.tool_widget.layout().addWidget(label_widget)
+            self.run_button.setEnabled(False)
             return
 
         # Build context widgets
@@ -258,12 +259,13 @@ class StandardLoaderDialog(BaseDialog):
         self.tool_widget.layout().addItem(spacer)
 
     def post_build_ui(self):
-        self._progress_widget.hide_overlay_signal.connect(
-            self.show_main_widget
-        )
-        self._progress_widget.show_overlay_signal.connect(
-            self.show_overlay_widget
-        )
+        if self._progress_widget:
+            self._progress_widget.hide_overlay_signal.connect(
+                self.show_main_widget
+            )
+            self._progress_widget.show_overlay_signal.connect(
+                self.show_overlay_widget
+            )
 
     def _on_run_button_clicked(self):
         '''(Override) Drive the progress widget'''

--- a/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
@@ -113,6 +113,7 @@ class StandardOpenerDialog(BaseContextDialog):
                 "font-style: italic; font-weight: bold;"
             )
             self.tool_widget.layout().addWidget(label_widget)
+            self.run_button.setEnabled(False)
             return
 
         # Build context widgets
@@ -160,12 +161,13 @@ class StandardOpenerDialog(BaseContextDialog):
         self.tool_widget.layout().addItem(spacer)
 
     def post_build_ui(self):
-        self._progress_widget.hide_overlay_signal.connect(
-            self.show_main_widget
-        )
-        self._progress_widget.show_overlay_signal.connect(
-            self.show_overlay_widget
-        )
+        if self._progress_widget:
+            self._progress_widget.hide_overlay_signal.connect(
+                self.show_main_widget
+            )
+            self._progress_widget.show_overlay_signal.connect(
+                self.show_overlay_widget
+            )
 
     def _on_run_button_clicked(self):
         '''(Override) Drive the progress widget'''

--- a/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
@@ -142,6 +142,7 @@ class StandardPublisherDialog(BaseContextDialog):
                 "font-style: italic; font-weight: bold;"
             )
             self.tool_widget.layout().addWidget(label_widget)
+            self.run_button.setEnabled(False)
             return
 
         # Build context widgets
@@ -236,12 +237,13 @@ class StandardPublisherDialog(BaseContextDialog):
             )
 
     def post_build_ui(self):
-        self._progress_widget.hide_overlay_signal.connect(
-            self.show_main_widget
-        )
-        self._progress_widget.show_overlay_signal.connect(
-            self.show_overlay_widget
-        )
+        if self._progress_widget:
+            self._progress_widget.hide_overlay_signal.connect(
+                self.show_main_widget
+            )
+            self._progress_widget.show_overlay_signal.connect(
+                self.show_overlay_widget
+            )
 
     def show_options_widget(self, widget):
         '''Sets the given *widget* as the index 2 of the stacked widget and

--- a/projects/framework-common-extensions/release_notes.md
+++ b/projects/framework-common-extensions/release_notes.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 
+* [fixed] Fix bug were dialog creation crashed if not tool configs. Also disabled run button.
 * [new] Exported paths validator to support image sequences.
 * [new] PySide6 support.
 * [new] PySide2 support.


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

framework-common-extensions:
* [fixed] Fix bug were dialog creation crashed if not tool configs. Also disabled run button.

## Test


            