### PR TITLE
fix: Fix invoke_in_qt_main_thread so it properly returns the result of the function

### DIFF
--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack QT library release Notes
 
+## upcoming
+
+* [fix] Fix invoke_in_qt_main_thread so it properly returns the result of the function.
+
 
 ## v2.2.1
 2024-05-07


### PR DESCRIPTION
…


<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [X] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [X] MacOs.
- [ ] Linux.


## Changes

_libs/qt:_

- [fix] Fix invoke_in_qt_main_thread so it properly returns the result of the function

## Test
