### PR TITLE
fix: Add missing Nuke loaders

### DIFF
--- a/projects/framework-nuke/extensions/nuke.yaml
+++ b/projects/framework-nuke/extensions/nuke.yaml
@@ -35,6 +35,8 @@ tools:
     options:
       tool_configs:
         - nuke-image-loader
+        - nuke-sequence-loader
+        - nuke-movie-loader
       docked: false
 
 

--- a/projects/framework-nuke/extensions/plugins/nuke_image_loader.py
+++ b/projects/framework-nuke/extensions/plugins/nuke_image_loader.py
@@ -10,7 +10,7 @@ from ftrack_framework_core.exceptions.plugin import PluginExecutionError
 
 
 class NukeImageLoaderPlugin(BasePlugin):
-    '''Load an image into Nuke'''
+    '''Load an image or sequence into Nuke'''
 
     name = 'nuke_image_loader'
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-


This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


## Changes

Added missing Nuke movie and sequence loaders

## Test

            