### PR TITLE
fix: Remove .capitalize() from plugin name

### DIFF
--- a/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
+++ b/tools/cookiecutter-framework-project/{{cookiecutter.project_name}}/extensions/plugins/{{ cookiecutter.integration_name }}_scene_opener.py
@@ -6,7 +6,7 @@ from ftrack_framework_core.exceptions.plugin import PluginExecutionError
 
 
 class {{ cookiecutter.integration_name.capitalize() }}SceneOpenerPlugin(BasePlugin):
-    name = '{{ cookiecutter.integration_name.capitalize() }}_scene_opener'
+    name = '{{ cookiecutter.integration_name }}_scene_opener'
 
     def run(self, store):
         '''


### PR DESCRIPTION
Remove .capitalize method from plugin name in cookiecutter template.