### PR TITLE
chore: Update upload/download action version to 4

### DIFF
--- a/.github/workflows/build-connect.yml
+++ b/.github/workflows/build-connect.yml
@@ -89,7 +89,7 @@ jobs:
           echo "Connect version: $CONNECT_VERSION"
           echo "connect_version=$CONNECT_VERSION" >> $GITHUB_OUTPUT
       - name: Prepare upload Connect wheel to GitHub Release
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ftrack-connect-whl
           path: ${{ needs.set-variables.outputs.folder }}/dist/ftrack_connect-${{ steps.get_version.outputs.connect_version }}-py3-none-any.whl

--- a/.github/workflows/build-library.yml
+++ b/.github/workflows/build-library.yml
@@ -77,7 +77,7 @@ jobs:
           cd ${{ needs.set-variables.outputs.folder }}
           poetry build
       - name: Upload temp artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ needs.set-variables.outputs.to_pypi == 'true' }}
         with:
           name: dist
@@ -93,7 +93,7 @@ jobs:
       url: https://test.pypi.org/project/ftrack-${{ needs.build-linux.outputs.package }}/
     steps:
       - name: Download temp artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -113,7 +113,7 @@ jobs:
       url: https://pypi.org/project/ftrack-${{ needs.build-linux.outputs.package }}/
     steps:
       - name: Download temp artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -133,7 +133,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload temp artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ needs.set-variables.outputs.to_pypi == 'true' }}
         with:
           name: dist

--- a/.github/workflows/push-main-test.yml
+++ b/.github/workflows/push-main-test.yml
@@ -45,7 +45,7 @@ jobs:
         if: ${{ matrix.python-version >= '3.8' }}
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage.${{ matrix.python-version }}
           include-hidden-files: true
           path: .coverage.${{ matrix.python-version }}
 
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/download-artifact@v3
         id: download
         with:
-          name: "coverage"
+          name: "coverage.3.11"
 
       - name: Coverage comment
         id: coverage_comment

--- a/.github/workflows/push-main-test.yml
+++ b/.github/workflows/push-main-test.yml
@@ -43,9 +43,10 @@ jobs:
 
       - name: Store coverage file
         if: ${{ matrix.python-version >= '3.8' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
+          include-hidden-files: true
           path: .coverage.${{ matrix.python-version }}
 
   coverage:
@@ -71,7 +72,7 @@ jobs:
           MERGE_COVERAGE_FILES: true
 
       - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           name: python-coverage-comment-action

--- a/.github/workflows/push-main-test.yml
+++ b/.github/workflows/push-main-test.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/download-artifact@v3
         id: download
         with:
-          name: "coverage.3.11"
+          name: "coverage.3.9"
 
       - name: Coverage comment
         id: coverage_comment

--- a/.github/workflows/push-main-test.yml
+++ b/.github/workflows/push-main-test.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         id: download
         with:
           name: "coverage.3.9"


### PR DESCRIPTION
Resolves FT-b87fed5c-05ad-466e-bed5-a18cbf0515cf

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains updates to the release notes.
- [ ] I have verified that the documentation is still up to date.

## Changes
- set upload/download artifact action version to 4 as 2 is deprecated and probably broke the CI
- set hidden file flag to allow for .coverage because of new breaking changes introduced by the action team
## Test
- is the CI passing?
