### PR TITLE
fix: Add hint for windows users using scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ To be sure that code is properly formatted before committing code, enable the Gi
 pip install pre-commit
 pre-commit install
 ```
+> [!NOTE]
+> If you are using windows and have installed python using `scoop`, don't forget to register the python version globally by running `<path-to-scoop-python>/install-pep-514.reg`. Otherwise, `pre-commit` might not be able to find your specific python version.
 
 ## Testing
 We run PyTest ^7.4 on the codebase to ensure the consistency of our monorepo.


### PR DESCRIPTION
Windows users might use the package manager scoop to install python on their system. pre-commit is not able to detect the correct python installation in that case.
Users will have to apply the scoop provided registry modification. This commit adds this information to the readme.

Resolves : 

* FT-cef61e51-33cc-4aeb-8313-58e47e8262e0


- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [x ] Windows.
- [ ] MacOs.
- [ ] Linux.
