### PR TITLE
fix: Removes obsolete pkg_resources import

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,9 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [fix] Remove obsolete pkg_resources import which lead to errors when launching through the commandline
+
 ## v24.9.0
 
 * [changed] Ftrack libraries updated to ^3.0.0.

--- a/apps/connect/source/ftrack_connect/__main__.py
+++ b/apps/connect/source/ftrack_connect/__main__.py
@@ -7,7 +7,6 @@ import argparse
 import logging
 import signal
 import os
-import pkg_resources
 import importlib
 
 from ftrack_connect.utils.plugin import (


### PR DESCRIPTION
Launching ftrack-connect fails on windows if setuptools is not installed globally or in the virtualenv. This is due to the pkg_resources import.
The import has been introduced 10 years ago via this commit: https://github.com/ftrackhq/integrations/commit/89f206dfdd31ae6d5994a7560d93da369ddd70c4

All usages have since been removed.

Resolves : 

* CLICKUP-
* FT-140bf5fb-0b06-44fc-8ec2-5d61026580ac
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ x] Windows.
- [ ] MacOs.
- [ ] Linux.
