### PR TITLE
fix: Backlog/handle ctrl c interrupt on windows

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [fix] Fix ctrl+c interrupt behaviour when launching connect through the commandline. It will now properly exit the application.
+
+
 ## v24.9.0
 
 * [changed] Ftrack libraries updated to ^3.0.0.

--- a/apps/connect/source/ftrack_connect/__main__.py
+++ b/apps/connect/source/ftrack_connect/__main__.py
@@ -8,7 +8,6 @@ import logging
 import signal
 import os
 import importlib
-from PySide6 import QtCore
 
 from ftrack_connect.utils.plugin import (
     create_target_plugin_directory,

--- a/apps/connect/source/ftrack_connect/__main__.py
+++ b/apps/connect/source/ftrack_connect/__main__.py
@@ -7,8 +7,8 @@ import argparse
 import logging
 import signal
 import os
-import pkg_resources
 import importlib
+from PySide6 import QtCore
 
 from ftrack_connect.utils.plugin import (
     create_target_plugin_directory,
@@ -138,8 +138,21 @@ def main_connect(arguments=None):
     application.setOrganizationDomain('ftrack.com')
     application.setQuitOnLastWindowClosed(False)
 
-    # Enable ctrl+c to quit application when started from command line.
-    signal.signal(signal.SIGINT, lambda sig, _: application.quit())
+    # Handle Ctrl+C (SIGINT) for both Windows and Unix-like systems
+    # Use a timer to allow Python interpreter to run and handle signals
+    timer = QtCore.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
+    class SignalHandler(QtCore.QObject):
+        signal_received = QtCore.Signal()
+
+    signal_handler = SignalHandler()
+    signal_handler.signal_received.connect(application.quit)
+
+    signal.signal(
+        signal.SIGINT, lambda *_: signal_handler.signal_received.emit()
+    )
 
     # Construct main connect window and apply theme.
     connectWindow = ftrack_connect.ui.application.Application(


### PR DESCRIPTION
Implements ctrl+c interrupt handling improvement

The prior method was not working on windows. Windows is not
creating a SIGINT signal from its console applications when
presseng ctrl+c. This new method works on all systems by
utilizing Qts internal signal handlers.

Resolves : 
* FT-ca59e6c3-8351-4067-bc52-cef6af407910


- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [x] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [x] Windows.
- [x] MacOs.
- [x] Linux.
