### PR TITLE
fix: Backlog/move pyside2 specific flag

### DIFF
--- a/apps/connect/release_notes.md
+++ b/apps/connect/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Connect release Notes
 
+## Upcoming
+
+* [changed] Move deprecated HighDPI settings into PySide2 specific codepath.
+
+
 ## v24.9.0
 
 * [changed] Ftrack libraries updated to ^3.0.0.

--- a/apps/connect/source/ftrack_connect/__main__.py
+++ b/apps/connect/source/ftrack_connect/__main__.py
@@ -7,7 +7,6 @@ import argparse
 import logging
 import signal
 import os
-import pkg_resources
 import importlib
 
 from ftrack_connect.utils.plugin import (
@@ -114,21 +113,20 @@ def main_connect(arguments=None):
             )
             raise SystemExit(1)
 
-    # If under X11, make Xlib calls thread-safe.
-    # http://stackoverflow.com/questions/31952711/threading-pyqt-crashes-with-unknown-request-in-queue-while-dequeuing
-
-    if os.name == 'posix' and is_pyside2:
+    if is_pyside2:
+        # These HighDPI settings are deprecated and enabled by default in PySide6.
         QtCore.QCoreApplication.setAttribute(
-            QtCore.Qt.ApplicationAttribute.AA_X11InitThreads
+            QtCore.Qt.AA_EnableHighDpiScaling, True
         )
-
-    # Ensure support for highdpi
-    QtCore.QCoreApplication.setAttribute(
-        QtCore.Qt.AA_EnableHighDpiScaling, True
-    )
-    QtCore.QCoreApplication.setAttribute(
-        QtCore.Qt.ApplicationAttribute.AA_UseHighDpiPixmaps, True
-    )
+        QtCore.QCoreApplication.setAttribute(
+            QtCore.Qt.ApplicationAttribute.AA_UseHighDpiPixmaps, True
+        )
+        # If under X11, make Xlib calls thread-safe.
+        # http://stackoverflow.com/questions/31952711/threading-pyqt-crashes-with-unknown-request-in-queue-while-dequeuing
+        if os.name == 'posix':
+            QtCore.QCoreApplication.setAttribute(
+                QtCore.Qt.ApplicationAttribute.AA_X11InitThreads
+            )
 
     # Construct global application.
 


### PR DESCRIPTION
    Move PySide2 specific HighDPI options

    This moves PySide2 specific HighDPI options into a PySide2
    specific codepath. This will get rid of Deprecation warnings
    within the PySide6 codepath. These options are not exposed
    anymore in PySide6 as they are enabled by default and not
    intended for turning them off.

Resolves : 

* CLICKUP-
* FT-0d89065a-8218-4b68-98e3-2278789550ca
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [x] Windows.
- [ ] MacOs.
- [ ] Linux.

