### PR TITLE
fix: rolling back str changes

### DIFF
--- a/libs/qt/source/ftrack_qt/utils/widget/__init__.py
+++ b/libs/qt/source/ftrack_qt/utils/widget/__init__.py
@@ -133,7 +133,7 @@ def build_progress_data(tool_config):
                 enabled = False
                 continue
             if 'options' in group:
-                tags.extend(list(str(group['options'].values())))
+                tags.extend(list(group['options'].values()))
             if 'tags' in group:
                 tags.extend(group['tags'])
         if enabled:

--- a/libs/utils/pyproject.toml
+++ b/libs/utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-utils"
-version = "3.1.1"
+version = "3.1.2"
 description='ftrack utils library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/utils/release_notes.md
+++ b/libs/utils/release_notes.md
@@ -1,5 +1,11 @@
 # ftrack Utils library release Notes
 
+## v3.1.2
+2024-10-28
+
+* [fix] Fix collecting tags on progress widget.
+
+
 ## v3.1.1
 2024-10-21
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-311b6500-a53f-4708-83ba-78cefe6a61b9
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


# Overview
**Purpose:** <!-- Briefly summarize what this PR does. -->
When querying the tags based on the options in the progres widget, there was a bug converting the string values to a list.

**Scope:** <!-- Indicate the main areas of the codebase affected. -->

## Implementation Details
**Approach:** <!-- Describe the chosen solution or method. -->

**Reasoning:** <!-- Explain why this approach was selected over alternatives. -->

**Changes:** <!-- Highlight the main code changes. -->

**Trade-offs:** <!-- Discuss any trade-offs or compromises made. -->

## Testing
**Tests Added:** <!-- Note any new tests. -->

**Manual Testing:** <!-- Describe any manual testing performed. -->

**Testing Environment:** <!-- Specify where the testing was conducted. -->

## Notes for Reviewers
**Focus Areas:** <!-- Suggest specific areas or aspects to review. -->

**Dependencies:** <!-- Mention any dependencies or prerequisites. -->

**Known Issues:** <!-- List any known issues or limitations. -->