### PR TITLE
fix:Add new session decorator back

### DIFF
--- a/libs/framework-core/pyproject.toml
+++ b/libs/framework-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-framework-core"
-version = "3.1.1"
+version = "3.1.2"
 description='ftrack Framework Core library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/framework-core/release_notes.md
+++ b/libs/framework-core/release_notes.md
@@ -1,7 +1,8 @@
 # ftrack Framework Core library release Notes
 
 
-## upcoming
+## v3.1.2
+2024-10-28
 
 * [fix] Host; Create new session when running a tool config to avoid corrupted sessions.
 

--- a/libs/framework-core/release_notes.md
+++ b/libs/framework-core/release_notes.md
@@ -1,6 +1,11 @@
 # ftrack Framework Core library release Notes
 
 
+## upcoming
+
+* [fix] Host; Create new session when running a tool config to avoid corrupted sessions.
+
+
 ## v3.1.1
 2024-10-04
 

--- a/libs/framework-core/source/ftrack_framework_core/host/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/host/__init__.py
@@ -266,7 +266,7 @@ class Host(object):
             )
             engine_instance = engine_registry['extension'](
                 self.registry,
-                session or self.session,
+                session,
                 self.context_id,
                 on_plugin_executed=self.on_plugin_executed_callback,
             )
@@ -332,7 +332,7 @@ class Host(object):
             )
             engine_instance = engine_registry['extension'](
                 self.registry,
-                session or self.session,
+                session,
                 on_plugin_executed=partial(
                     self.on_ui_hook_executed_callback, plugin_reference
                 ),

--- a/libs/framework-core/source/ftrack_framework_core/host/__init__.py
+++ b/libs/framework-core/source/ftrack_framework_core/host/__init__.py
@@ -229,7 +229,8 @@ class Host(object):
 
     # Run
     @delegate_to_main_thread_wrapper
-    def run_tool_config_callback(self, event):
+    @with_new_session
+    def run_tool_config_callback(self, event, session=None):
         '''
         Runs the data with the defined engine type of the given *event*
 
@@ -265,7 +266,7 @@ class Host(object):
             )
             engine_instance = engine_registry['extension'](
                 self.registry,
-                self.session,
+                session or self.session,
                 self.context_id,
                 on_plugin_executed=self.on_plugin_executed_callback,
             )
@@ -295,7 +296,8 @@ class Host(object):
         self.event_manager.publish.host_log_item_added(self.id, log_item)
 
     @delegate_to_main_thread_wrapper
-    def run_ui_hook_callback(self, event):
+    @with_new_session
+    def run_ui_hook_callback(self, event, session=None):
         '''
         Runs the data with the defined engine type of the given *event*
 
@@ -330,7 +332,7 @@ class Host(object):
             )
             engine_instance = engine_registry['extension'](
                 self.registry,
-                self.session,
+                session or self.session,
                 on_plugin_executed=partial(
                     self.on_ui_hook_executed_callback, plugin_reference
                 ),


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-95a424a9-fc6f-48c0-88c1-221e1e65e77a
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


# Overview
**Purpose:** <!-- Briefly summarize what this PR does. -->
Make sure we always create a new session when running tool configs on host. So we can avoid corrupted sessions.

**Scope:** <!-- Indicate the main areas of the codebase affected. -->

## Implementation Details
**Approach:** <!-- Describe the chosen solution or method. -->

**Reasoning:** <!-- Explain why this approach was selected over alternatives. -->

**Changes:** <!-- Highlight the main code changes. -->

**Trade-offs:** <!-- Discuss any trade-offs or compromises made. -->

## Testing
**Tests Added:** <!-- Note any new tests. -->

**Manual Testing:** <!-- Describe any manual testing performed. -->

**Testing Environment:** <!-- Specify where the testing was conducted. -->

## Notes for Reviewers
**Focus Areas:** <!-- Suggest specific areas or aspects to review. -->

**Dependencies:** <!-- Mention any dependencies or prerequisites. -->

**Known Issues:** <!-- List any known issues or limitations. -->