### PR TITLE
fix: Roll back release notes on utils and add release notes and release qt

### DIFF
--- a/libs/qt/pyproject.toml
+++ b/libs/qt/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-qt"
-version = "3.0.0"
+version = "3.0.1"
 description='ftrack qt library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -1,7 +1,7 @@
 # ftrack QT library release Notes
 
 
-## v3.1.1
+## v3.0.1
 2024-10-28
 
 * [fix] Fix collecting tags on progress widget.

--- a/libs/qt/release_notes.md
+++ b/libs/qt/release_notes.md
@@ -1,5 +1,12 @@
 # ftrack QT library release Notes
 
+
+## v3.1.1
+2024-10-28
+
+* [fix] Fix collecting tags on progress widget.
+
+
 ## v3.0.0
 2024-09-19
 

--- a/libs/utils/pyproject.toml
+++ b/libs/utils/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ftrack-utils"
-version = "3.1.2"
+version = "3.1.3"
 description='ftrack utils library'
 authors = ["ftrack Integrations Team <integrations@backlight.co>"]
 readme = "README.md"

--- a/libs/utils/release_notes.md
+++ b/libs/utils/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Utils library release Notes
 
+## v3.1.3
+2024-10-28
+
+* ~~[fix] Fix collecting tags on progress widget.~~
+
 ## v3.1.2
 2024-10-28
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


# Overview
**Purpose:** <!-- Briefly summarize what this PR does. -->
Fix mistake releasing utils when we should have been releasing qt.

**Scope:** <!-- Indicate the main areas of the codebase affected. -->

## Implementation Details
**Approach:** <!-- Describe the chosen solution or method. -->

**Reasoning:** <!-- Explain why this approach was selected over alternatives. -->

**Changes:** <!-- Highlight the main code changes. -->

**Trade-offs:** <!-- Discuss any trade-offs or compromises made. -->

## Testing
**Tests Added:** <!-- Note any new tests. -->

**Manual Testing:** <!-- Describe any manual testing performed. -->

**Testing Environment:** <!-- Specify where the testing was conducted. -->

## Notes for Reviewers
**Focus Areas:** <!-- Suggest specific areas or aspects to review. -->

**Dependencies:** <!-- Mention any dependencies or prerequisites. -->

**Known Issues:** <!-- List any known issues or limitations. -->