### PR TITLE
fix: set loger level of non usage tracker to debug insteaad of error

### DIFF
--- a/libs/utils/release_notes.md
+++ b/libs/utils/release_notes.md
@@ -1,5 +1,10 @@
 # ftrack Utils library release Notes
 
+## upcoming
+
+
+* [changed] UsageTracker; Change the log level when UsageTracker is not created to debug.
+
 ## v3.1.3
 2024-10-28
 

--- a/libs/utils/source/ftrack_utils/usage/track_usage.py
+++ b/libs/utils/source/ftrack_utils/usage/track_usage.py
@@ -25,7 +25,7 @@ def set_usage_tracker(usage_tracker):
     if usage_tracker_singleton is None:
         usage_tracker_singleton = usage_tracker
     else:
-        logger.error(
+        logger.debug(
             "UsageTracker instance is already set. Ignoring the new instance."
         )
 


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-7ec0e3f3-cb47-4908-aba6-4b50e7953136
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


# Overview
**Purpose:** <!-- Briefly summarize what this PR does. -->
Change the usage tracker log error of not having an existing instance to debug.

**Scope:** <!-- Indicate the main areas of the codebase affected. -->

## Implementation Details
**Approach:** <!-- Describe the chosen solution or method. -->

**Reasoning:** <!-- Explain why this approach was selected over alternatives. -->

**Changes:** <!-- Highlight the main code changes. -->

**Trade-offs:** <!-- Discuss any trade-offs or compromises made. -->

## Testing
**Tests Added:** <!-- Note any new tests. -->

**Manual Testing:** <!-- Describe any manual testing performed. -->

**Testing Environment:** <!-- Specify where the testing was conducted. -->

## Notes for Reviewers
**Focus Areas:** <!-- Suggest specific areas or aspects to review. -->

**Dependencies:** <!-- Mention any dependencies or prerequisites. -->

**Known Issues:** <!-- List any known issues or limitations. -->