### PR TITLE
fix: selection export and playblast creation

### DIFF
--- a/projects/framework-blender/extensions/plugins/blender_object_mode_validator.py
+++ b/projects/framework-blender/extensions/plugins/blender_object_mode_validator.py
@@ -1,0 +1,55 @@
+# :coding: utf-8
+# :copyright: Copyright (c) 2024 ftrack
+
+import bpy
+
+from ftrack_utils.paths import get_temp_path
+
+from ftrack_framework_core.plugin import BasePlugin
+from ftrack_framework_core.exceptions.plugin import (
+    PluginExecutionError,
+    PluginValidationError,
+)
+
+
+class BlenderObjectModeValidatorPlugin(BasePlugin):
+    name = "blender_object_mode_validator"
+
+    def set_mesh_objects_to_object_mode(self, store, mesh_objects_in_edit_mode):
+        """
+        Set all mesh objects that are currently in edit mode to object mode.
+        """
+
+
+        active_object = bpy.context.view_layer.objects.active
+        try:
+            for obj in mesh_objects_in_edit_mode:
+                bpy.context.view_layer.objects.active = obj
+                bpy.ops.object.mode_set(mode="OBJECT")
+        except Exception as error:
+            raise PluginExecutionError(message=error)
+        finally:
+            bpy.context.view_layer.objects.active = active_object
+
+    def run(self, store):
+        """
+        Checks if any mesh objects are currently in edit mode.
+        We can only export a selection if all mesh objects are in object mode.
+        """
+
+        mesh_objects_in_edit_mode = [
+            obj for obj in bpy.context.scene.objects
+            if obj.type == "MESH"
+            and  obj.mode == "EDIT"
+        ]
+
+        if mesh_objects_in_edit_mode:
+            self.logger.warning(
+                f'Some objects are still in EDIT mode. {[_.name for _ in mesh_objects_in_edit_mode]}'
+            )
+            raise PluginValidationError(
+                message="Foobar",
+                on_fix_callback=lambda _: self.set_mesh_objects_to_object_mode(store, mesh_objects_in_edit_mode),
+            )
+
+        self.logger.debug("All mesh objects are properly set to object mode.")

--- a/projects/framework-blender/extensions/plugins/blender_object_mode_validator.py
+++ b/projects/framework-blender/extensions/plugins/blender_object_mode_validator.py
@@ -15,11 +15,12 @@ from ftrack_framework_core.exceptions.plugin import (
 class BlenderObjectModeValidatorPlugin(BasePlugin):
     name = "blender_object_mode_validator"
 
-    def set_mesh_objects_to_object_mode(self, store, mesh_objects_in_edit_mode):
+    def set_mesh_objects_to_object_mode(
+        self, store, mesh_objects_in_edit_mode
+    ):
         """
         Set all mesh objects that are currently in edit mode to object mode.
         """
-
 
         active_object = bpy.context.view_layer.objects.active
         try:
@@ -38,9 +39,9 @@ class BlenderObjectModeValidatorPlugin(BasePlugin):
         """
 
         mesh_objects_in_edit_mode = [
-            obj for obj in bpy.context.scene.objects
-            if obj.type == "MESH"
-            and  obj.mode == "EDIT"
+            obj
+            for obj in bpy.context.scene.objects
+            if obj.type == "MESH" and obj.mode == "EDIT"
         ]
 
         if mesh_objects_in_edit_mode:
@@ -48,8 +49,10 @@ class BlenderObjectModeValidatorPlugin(BasePlugin):
                 f'Some objects are still in EDIT mode. {[_.name for _ in mesh_objects_in_edit_mode]}'
             )
             raise PluginValidationError(
-                message="Foobar",
-                on_fix_callback=lambda _: self.set_mesh_objects_to_object_mode(store, mesh_objects_in_edit_mode),
+                message=f"Some objects are still in EDIT mode. Can't export scene.",
+                on_fix_callback=lambda _: self.set_mesh_objects_to_object_mode(
+                    store, mesh_objects_in_edit_mode
+                ),
             )
 
         self.logger.debug("All mesh objects are properly set to object mode.")

--- a/projects/framework-blender/extensions/plugins/blender_playblast_exporter.py
+++ b/projects/framework-blender/extensions/plugins/blender_playblast_exporter.py
@@ -6,6 +6,7 @@ import bpy
 from ftrack_utils.paths import get_temp_path
 
 from ftrack_framework_core.plugin import BasePlugin
+from ftrack_framework_core.exceptions.plugin import PluginExecutionError
 
 
 class BlenderPlayblastExporterPlugin(BasePlugin):
@@ -20,24 +21,46 @@ class BlenderPlayblastExporterPlugin(BasePlugin):
 
         # Set the output file path
         save_path = get_temp_path(filename_extension='.mp4')
+        camera_name = store['components'][component_name]['camera_name']
 
-        scene = bpy.context.scene
-        rd = scene.render
+        bpy.ops.ed.undo_push(message="ftrack: Export Playblast")
+        try:
+            rd = bpy.context.scene.render
 
-        # Set the viewport resolution
-        rd.resolution_x = 1920
-        rd.resolution_y = 1080
+            camera = [
+                obj for obj in bpy.data.objects
+                  if obj.type == 'CAMERA'
+                  and obj.name == camera_name
+            ][0]
 
-        # Set the output format
-        rd.image_settings.file_format = "FFMPEG"
-        # Set output format
-        rd.ffmpeg.format = "MPEG4"
-        # Set the codec
-        rd.ffmpeg.codec = "H264"
+            bpy.context.scene.camera = camera
 
-        # Render the viewport and save the result
-        bpy.context.scene.render.filepath = save_path
-        bpy.ops.render.render(animation=True, use_viewport=True, write_still=True)
-        self.logger.debug(f'Rendering playblast to {save_path}')
+            # Set the viewport resolution
+            rd.resolution_x = 1920
+            rd.resolution_y = 1080
 
-        store['components'][component_name]['exported_path'] = save_path
+            # Set the output format
+            rd.image_settings.file_format = "FFMPEG"
+            # Set output format
+            rd.ffmpeg.format = "MPEG4"
+            # Set the codec
+            rd.ffmpeg.codec = "H264"
+
+            # Render the viewport and save the result
+            bpy.context.scene.render.filepath = save_path
+            self.logger.debug(f'Rendering playblast to {save_path}')
+
+            bpy.ops.render.render(
+                animation=True,
+                use_viewport=False,
+                write_still=True
+            )
+
+            store['components'][component_name]['exported_path'] = save_path
+
+        except Exception as error:
+            raise PluginExecutionError(
+                message=f"Couldn't export playblast to {save_path} due to error:{error}"
+            )
+        finally:
+            bpy.ops.ed.undo()

--- a/projects/framework-blender/extensions/plugins/blender_scene_exporter.py
+++ b/projects/framework-blender/extensions/plugins/blender_scene_exporter.py
@@ -28,7 +28,7 @@ class BlenderSceneExporterPlugin(BasePlugin):
                 exported_path = get_temp_path(filename_extension='.blend')
 
                 # open the undo group
-                bpy.ops.ed.undo_push()
+                bpy.ops.ed.undo_push(message="ftrack: Export selection")
 
                 internal_scene_name = bpy.context.scene.name
                 bpy.context.scene.name = f"{internal_scene_name}_temp"

--- a/projects/framework-blender/extensions/plugins/blender_thumbnail_exporter.py
+++ b/projects/framework-blender/extensions/plugins/blender_thumbnail_exporter.py
@@ -22,13 +22,14 @@ class BlenderThumbnailExporterPlugin(BasePlugin):
         exported_path = get_temp_path(filename_extension='.jpg')
         self.logger.debug(f'Rendering thumbnail to {exported_path}')
 
-        bpy.ops.ed.undo_push()
+        bpy.ops.ed.undo_push(message="ftrack: Export Thumbnail")
         try:
             bpy.context.scene.render.image_settings.file_format = "JPEG"
             bpy.context.scene.render.filepath = exported_path
             bpy.ops.render.opengl(
                 animation=False,
-                write_still=True
+                write_still=True,
+                view_context=True
             )
         except Exception as error:
             raise PluginExecutionError(

--- a/projects/framework-blender/extensions/tool-configs/blender-scene-publisher.yaml
+++ b/projects/framework-blender/extensions/tool-configs/blender-scene-publisher.yaml
@@ -9,6 +9,10 @@ engine:
     options:
       asset_type_name: scene
     ui: publisher_asset_version_selector
+  - type: plugin
+    tags:
+      - validator
+    plugin: blender_object_mode_validator
 
   # Export the snapshot component.
   - type: group


### PR DESCRIPTION
Playblasts will now be generated with the correctly selected camera.
Selection exports now work when objects are in edit mode. There's a new validator that includes a fix to set the objects to OBJECT mode.


- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [x] Windows.
- [ ] MacOs.
- [ ] Linux.

