### PR TITLE
fix: update macos12 to macos13 on the runner actions. 12 is deprecated.

### DIFF
--- a/.github/workflows/build-connect.yml
+++ b/.github/workflows/build-connect.yml
@@ -58,7 +58,7 @@ jobs:
   connect-build:
     name: Build Connect
     needs: set-variables
-    runs-on: macos-12 # Temporary setting macos-12 as OS instead of UBUNTU because python 6.6 onward has problems building resources on linux. (6.5 works but increases connect file size to double)
+    runs-on: macos-13 # Temporary setting macos-12 as OS instead of UBUNTU because python 6.6 onward has problems building resources on linux. (6.5 works but increases connect file size to double)
     outputs:
       connect_version: ${{ steps.get_version.outputs.connect_version }}
     steps:
@@ -158,7 +158,7 @@ jobs:
   installer-macos:
     name: Build Connect Installer on MacOs
     needs: [ set-variables, connect-build ]
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       CODESIGN: 'True' # A not codesigned dmg will always show damaged app. Please build locally if don't want to codesign and generate a ZIP instead of a dmg.
     steps:

--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -183,7 +183,7 @@ jobs:
     concurrency:
       group: ci-${{ github.ref }}
     if: ${{ needs.set-variables.outputs.package == 'framework-photoshop' || needs.set-variables.outputs.package == 'framework-premiere' || needs.set-variables.outputs.package == 'framework-blender' }}
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
<!--(
  Copy the id and paste it to the appropriate CLICKUP-<id> / FTRACK-<id> /  SENTRY-<id> / ZENDESK-<id> link.
  Please remember to remove the unused ones.
-->

Resolves : 

* CLICKUP-
* FT-
* SENTRY-
* ZENDESK-

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


# Overview
**Purpose:** <!-- Briefly summarize what this PR does. -->
Macos12 runner is deprecated. Updated to 13.

**Scope:** <!-- Indicate the main areas of the codebase affected. -->

## Implementation Details
**Approach:** <!-- Describe the chosen solution or method. -->

**Reasoning:** <!-- Explain why this approach was selected over alternatives. -->

**Changes:** <!-- Highlight the main code changes. -->

**Trade-offs:** <!-- Discuss any trade-offs or compromises made. -->

## Testing
**Tests Added:** <!-- Note any new tests. -->

**Manual Testing:** <!-- Describe any manual testing performed. -->

**Testing Environment:** <!-- Specify where the testing was conducted. -->

## Notes for Reviewers
**Focus Areas:** <!-- Suggest specific areas or aspects to review. -->

**Dependencies:** <!-- Mention any dependencies or prerequisites. -->

**Known Issues:** <!-- List any known issues or limitations. -->