### PR TITLE
fix: Properly parse Adobe Beta versions

### DIFF
--- a/apps/connect/source/ftrack_connect/application_launcher/__init__.py
+++ b/apps/connect/source/ftrack_connect/application_launcher/__init__.py
@@ -24,6 +24,7 @@ from ftrack_utils.usage import get_usage_tracker
 from ftrack_utils.version import (
     DEFAULT_VERSION_EXPRESSION,
     parse_application_version,
+    resolve_marketing_version,
 )
 from packaging.version import Version
 
@@ -193,6 +194,7 @@ class ApplicationStore(object):
         environment_variables=None,
         connect_plugin_path=None,
         rosetta=False,
+        version_year_offset=None,
     ):
         r"""
         Return list of applications found in filesystem matching *expression*.
@@ -301,6 +303,11 @@ class ApplicationStore(object):
 
                         versionMatch = versionExpression.search(path)
                         loose_version = Version("0")
+                        # Only apply version_year_offset when the
+                        # version comes from Info.plist, not when
+                        # it was already extracted as a marketing
+                        # year from the filesystem path.
+                        effective_offset = None
 
                         if versionMatch:
                             version = versionMatch.group("version")
@@ -332,9 +339,17 @@ class ApplicationStore(object):
                                         loose_version = (
                                             parse_application_version(version)
                                         )
+                                        effective_offset = version_year_offset
 
-                        variant_str = variant.format(
-                            version=str(loose_version)
+                        loose_version, beta_suffix = resolve_marketing_version(
+                            loose_version,
+                            effective_offset,
+                            path,
+                        )
+
+                        variant_str = (
+                            variant.format(version=str(loose_version))
+                            + beta_suffix
                         )
 
                         if integrations:
@@ -1145,7 +1160,11 @@ class ApplicationLaunchAction(BaseAction):
         applications = self.application_store.applications
 
         applications = sorted(
-            applications, key=lambda application: application["label"]
+            applications,
+            key=lambda application: (
+                application["label"],
+                application.get("variant", ""),
+            ),
         )
 
         for application in applications:

--- a/apps/connect/source/ftrack_connect/application_launcher/discover_applications.py
+++ b/apps/connect/source/ftrack_connect/application_launcher/discover_applications.py
@@ -27,7 +27,7 @@ class DiscoverApplications(object):
     def __init__(self, session, applications_config_paths):
         super(DiscoverApplications, self).__init__()
         self.logger = logging.getLogger(
-            __name__ + '.' + self.__class__.__name__
+            __name__ + "." + self.__class__.__name__
         )
 
         # If a single path is passed by mistake, handle it here.
@@ -41,7 +41,7 @@ class DiscoverApplications(object):
         self._build_launchers(configurations)
 
     def _parse_configurations(self, config_paths):
-        '''Use the extensions library to load and merge launch configurations'''
+        """Use the extensions library to load and merge launch configurations"""
         loaded_filtered_files = []
         connect_extensions_path = (
             get_connect_extensions_path_from_environment()
@@ -51,7 +51,7 @@ class DiscoverApplications(object):
                 config_path
             ):
                 self.logger.warning(
-                    '{} directory cannot be found.'.format(config_path)
+                    "{} directory cannot be found.".format(config_path)
                 )
                 continue
 
@@ -60,32 +60,32 @@ class DiscoverApplications(object):
         # Load and merge all launch configs from the extensions path
         registry_instance = registry.Registry()
         registry_instance.scan_extensions(
-            paths=connect_extensions_path, extension_types=['launch_config']
+            paths=connect_extensions_path, extension_types=["launch_config"]
         )
 
         for launcher_extension in registry_instance.launch_configs or []:
             loaded_filtered_files.append(
-                (launcher_extension['extension'], launcher_extension['path'])
+                (launcher_extension["extension"], launcher_extension["path"])
             )
             self.logger.info(
-                'Loaded launcher config extension: {}'.format(
-                    launcher_extension['extension']
+                "Loaded launcher config extension: {}".format(
+                    launcher_extension["extension"]
                 )
             )
 
         self.logger.debug(
-            'Launcher configs found: {}'.format(len(loaded_filtered_files))
+            "Launcher configs found: {}".format(len(loaded_filtered_files))
         )
 
         return loaded_filtered_files
 
     def _group_configurations(self, configurations):
-        '''group configuration based on identifier'''
+        """group configuration based on identifier"""
         result_dict = defaultdict(list)
 
         for configuration, path in configurations:
             try:
-                result_dict.setdefault(configuration['identifier'], []).append(
+                result_dict.setdefault(configuration["identifier"], []).append(
                     (configuration, path)
                 )
             except Exception as e:
@@ -103,7 +103,7 @@ class DiscoverApplications(object):
             identified_configuration,
         ) in grouped_configurations.items():
             self.logger.debug(
-                'building config store for {}({})'.format(
+                "building config store for {}({})".format(
                     identifier, len(identified_configuration)
                 )
             )
@@ -111,57 +111,58 @@ class DiscoverApplications(object):
 
             for config, config_path in identified_configuration:
                 # extract data from app config
-                search_path = config['search_path'].get(self.current_os)
+                search_path = config["search_path"].get(self.current_os)
                 if not search_path:
                     self.logger.info(
-                        'No entry found for os: {} in config {}'.format(
-                            self.current_os, config['label']
+                        "No entry found for os: {} in config {}".format(
+                            self.current_os, config["label"]
                         )
                     )
                     continue
 
-                launch_arguments = search_path.get('launch_arguments')
-                prefix = search_path['prefix']
-                expression = search_path['expression']
-                version_expression = search_path.get('version_expression')
+                launch_arguments = search_path.get("launch_arguments")
+                prefix = search_path["prefix"]
+                expression = search_path["expression"]
+                version_expression = search_path.get("version_expression")
                 # Does the launcher needs the app on rosetta mode?
-                rosetta = search_path.get('rosetta')
+                rosetta = search_path.get("rosetta")
                 applications = store._search_filesystem(
                     versionExpression=version_expression,
                     expression=prefix + expression,
-                    label=config['label'],
-                    applicationIdentifier=config['applicationIdentifier'],
-                    icon=config['icon'],
-                    variant=config['variant'],
+                    label=config["label"],
+                    applicationIdentifier=config["applicationIdentifier"],
+                    icon=config["icon"],
+                    variant=config["variant"],
                     launchArguments=launch_arguments,
-                    integrations=config.get('integrations'),
-                    standalone_module=config.get('standalone_module'),
-                    extensions_path=config.get('extensions_path'),
-                    environment_variables=config.get('environment_variables'),
+                    integrations=config.get("integrations"),
+                    standalone_module=config.get("standalone_module"),
+                    extensions_path=config.get("extensions_path"),
+                    environment_variables=config.get("environment_variables"),
                     connect_plugin_path=os.path.realpath(
-                        os.path.join(os.path.dirname(config_path), '..')
+                        os.path.join(os.path.dirname(config_path), "..")
                     ),
                     rosetta=rosetta,
+                    version_year_offset=config.get("version_year_offset"),
                 )
                 store.applications.extend(applications)
 
             launcher = ApplicationLauncher(store)
             NewAction = type(
-                'ApplicationLauncherAction-{}'.format(config['label']),
+                "ApplicationLauncherAction-{}".format(config["label"]),
                 (ApplicationLaunchAction,),
                 {
-                    'label': config['label'],
-                    'identifier': identifier,
-                    'context': config['context'],
+                    "label": config["label"],
+                    "identifier": identifier,
+                    "context": config["context"],
                 },
             )
-            priority = config.get('priority', sys.maxsize)
+            priority = config.get("priority", sys.maxsize)
             action = NewAction(
                 self._session, store, launcher, priority=priority
             )
 
             self.logger.debug(
-                'Creating App launcher {} with priority {}'.format(
+                "Creating App launcher {} with priority {}".format(
                     action, priority
                 )
             )
@@ -169,18 +170,18 @@ class DiscoverApplications(object):
             self._actions.append(action)
 
     def get_debug_information(self):
-        '''Return all launcher actions as debug information'''
+        """Return all launcher actions as debug information"""
         result = {
-            'name': 'Application Launcher',
-            'identifier': 'application.launch',
-            'actions': [],
+            "name": "Application Launcher",
+            "identifier": "application.launch",
+            "actions": [],
         }
         for action in self._actions:
-            result['actions'].append(action.get_debug_information())
+            result["actions"].append(action.get_debug_information())
         return result
 
     def register(self):
         for action in self._actions:
             action.register()
 
-        self.logger.debug('Registered {} action(s)'.format(len(self._actions)))
+        self.logger.debug("Registered {} action(s)".format(len(self._actions)))

--- a/libs/utils/source/ftrack_utils/version/__init__.py
+++ b/libs/utils/source/ftrack_utils/version/__init__.py
@@ -30,6 +30,26 @@ def parse_application_version(value):
     return Version("0")
 
 
+def resolve_marketing_version(loose_version, version_year_offset, path):
+    """Resolve a marketing version from an internal version.
+
+    If *version_year_offset* is set, converts the major component of
+    *loose_version* to a marketing year (e.g. major 27 + 1999 = 2026).
+
+    If *path* contains "(Beta)", returns a " (beta)" suffix.
+
+    Returns a tuple of (*resolved_version*, *beta_suffix*) where
+    *beta_suffix* is either " (beta)" or "".
+    """
+    if version_year_offset is not None and loose_version > Version("0"):
+        year = loose_version.major + version_year_offset
+        loose_version = Version(str(year))
+
+    beta_suffix = " (beta)" if "(Beta)" in path else ""
+
+    return loose_version, beta_suffix
+
+
 def get_version(package_name, package_path):
     """Return version string for *package_name* at *package_path*"""
     result = "0.0.0"

--- a/projects/framework-aftereffects/connect-plugin/hook/discover_ftrack_framework_aftereffects.py
+++ b/projects/framework-aftereffects/connect-plugin/hook/discover_ftrack_framework_aftereffects.py
@@ -1,0 +1,108 @@
+# :coding: utf-8
+# :copyright: Copyright (c) 2024 ftrack
+
+import os
+import ftrack_api
+import logging
+import functools
+import uuid
+
+from ftrack_utils.version import get_connect_plugin_version
+
+# The name of the integration, should match name in launcher.
+NAME = "framework-aftereffects"
+
+
+logger = logging.getLogger(__name__)
+
+cwd = os.path.dirname(__file__)
+connect_plugin_path = os.path.abspath(os.path.join(cwd, ".."))
+
+# Read version number from __version__.py
+__version__ = get_connect_plugin_version(connect_plugin_path)
+
+python_dependencies = os.path.join(connect_plugin_path, "dependencies")
+
+
+def on_discover_integration(session, event):
+    data = {
+        "integration": {
+            "name": NAME,
+            "version": __version__,
+        }
+    }
+
+    return data
+
+
+def on_launch_integration(session, event):
+    """Handle application launch and add environment to *event*."""
+
+    launch_data = {"integration": event["data"]["integration"]}
+
+    discover_data = on_discover_integration(session, event)
+    for key in discover_data["integration"]:
+        launch_data["integration"][key] = discover_data["integration"][key]
+
+    integration_version = event["data"]["application"]["version"].version[0]
+
+    logger.info(
+        f"Launching integration v{integration_version} assuming CEP plugin has "
+        "been properly installed prior to launch."
+    )
+
+    if not launch_data["integration"].get("env"):
+        launch_data["integration"]["env"] = {}
+
+    launch_data["integration"]["env"]["PYTHONPATH.prepend"] = (
+        os.path.pathsep.join([python_dependencies])
+    )
+    launch_data["integration"]["env"][
+        "FTRACK_REMOTE_INTEGRATION_SESSION_ID"
+    ] = str(uuid.uuid4())
+
+    launch_data["integration"]["env"]["FTRACK_AFTEREFFECTS_VERSION"] = str(
+        integration_version
+    )
+
+    selection = event["data"].get("context", {}).get("selection", [])
+
+    if selection:
+        task = session.get("Context", selection[0]["entityId"])
+        launch_data["integration"]["env"]["FTRACK_CONTEXTID.set"] = task["id"]
+
+    return launch_data
+
+
+def register(session):
+    """Subscribe to application launch events on *registry*."""
+    if not isinstance(session, ftrack_api.session.Session):
+        return
+
+    handle_discovery_event = functools.partial(
+        on_discover_integration, session
+    )
+
+    session.event_hub.subscribe(
+        "topic=ftrack.connect.application.discover and "
+        "data.application.identifier=aftereffects*"
+        " and data.application.version >= 15.0",
+        handle_discovery_event,
+        priority=40,
+    )
+
+    handle_launch_event = functools.partial(on_launch_integration, session)
+
+    session.event_hub.subscribe(
+        "topic=ftrack.connect.application.launch and "
+        "data.application.identifier=aftereffects*"
+        " and data.application.version >= 15.0",
+        handle_launch_event,
+        priority=40,
+    )
+
+    logger.info(
+        "Registered {} integration v{} discovery and launch.".format(
+            NAME, __version__
+        )
+    )

--- a/projects/framework-aftereffects/extensions/launch/aftereffects-launch.yaml
+++ b/projects/framework-aftereffects/extensions/launch/aftereffects-launch.yaml
@@ -1,0 +1,35 @@
+type: launch_config
+name: framework-aftereffects
+priority: 100
+context:
+  - Task
+identifier: ftrack-framework-launch-aftereffects
+applicationIdentifier: aftereffects_{variant}
+integrations:
+  framework:
+    - framework-aftereffects
+label: Adobe After Effects
+icon: after_effects
+variant: "{version}"
+version_year_offset: 2000
+search_path:
+  windows:
+    prefix:
+      - C:\
+      - Program Files.*
+      - Adobe
+    expression:
+      - Adobe After Effects*
+      - Support Files
+      - AfterFX.exe
+  darwin:
+    prefix:
+      - "/"
+      - Applications
+    expression:
+      - Adobe After Effects*
+      - Adobe After Effects (\d+|\(Beta\))\.app
+standalone_module: ftrack_framework_aftereffects
+extensions_path:
+  - extensions/common
+  - extensions/aftereffects

--- a/projects/framework-photoshop/extensions/launch/photoshop-launch.yaml
+++ b/projects/framework-photoshop/extensions/launch/photoshop-launch.yaml
@@ -11,6 +11,7 @@ integrations:
 label: Adobe Photoshop
 icon: photoshop
 variant: "{version}"
+version_year_offset: 1999
 search_path:
   windows:
     prefix:

--- a/projects/framework-premiere/extensions/launch/premiere-launch.yaml
+++ b/projects/framework-premiere/extensions/launch/premiere-launch.yaml
@@ -11,6 +11,7 @@ integrations:
 label: Adobe Premiere
 icon: premiere
 variant: "{version}"
+version_year_offset: 2000
 search_path:
   windows:
     prefix:

--- a/tests/libraries/test_version_parsing.py
+++ b/tests/libraries/test_version_parsing.py
@@ -1,8 +1,12 @@
 import re
 
+import pytest
+from packaging.version import Version
+
 from ftrack_utils.version import (
     DEFAULT_VERSION_EXPRESSION,
     parse_application_version,
+    resolve_marketing_version,
 )
 
 
@@ -26,6 +30,61 @@ def test_default_version_expression_extracts_dcc_style_version_token():
     match = DEFAULT_VERSION_EXPRESSION.search(path)
     assert match is not None
     assert match.group("version") == "1.8v2b1"
+
+
+@pytest.mark.parametrize(
+    "version, offset, path, expected_version, expected_suffix",
+    [
+        pytest.param(
+            "27.7.0",
+            1999,
+            "/path/to/App (Beta)/App (Beta).app",
+            "2026",
+            " (beta)",
+            id="beta-with-offset",
+        ),
+        pytest.param(
+            "26.3.0",
+            2000,
+            "/path/to/App 2026/App.exe",
+            "2026",
+            "",
+            id="stable-with-offset",
+        ),
+        pytest.param(
+            "27.7.0",
+            None,
+            "/path/to/App (Beta)/App (Beta).app",
+            "27.7.0",
+            " (beta)",
+            id="beta-without-offset",
+        ),
+        pytest.param(
+            "2026",
+            None,
+            "/path/to/App 2026/App.app",
+            "2026",
+            "",
+            id="stable-without-offset",
+        ),
+        pytest.param(
+            "0",
+            1999,
+            "/path/to/App (Beta)/App.exe",
+            "0",
+            " (beta)",
+            id="beta-zero-version-skips-offset",
+        ),
+    ],
+)
+def test_resolve_marketing_version(
+    version, offset, path, expected_version, expected_suffix
+):
+    resolved, suffix = resolve_marketing_version(
+        Version(version), offset, path
+    )
+    assert str(resolved) == expected_version
+    assert suffix == expected_suffix
 
 
 def test_project_version_expression_patterns_from_launch_configs_are_valid():


### PR DESCRIPTION
Includes scaffoling for other apps that have deviating internal versoning vs. marketing (datebased) versioning.

Resolves :  fi-20