### PR TITLE
fix: robust ftrack panel init and context-aware errors in RV

### DIFF
--- a/projects/rv/resource/plugin/ftrack.py
+++ b/projects/rv/resource/plugin/ftrack.py
@@ -7,9 +7,12 @@ import re
 import tempfile
 import os
 import logging
-import platform
 import base64
+import html
 import importlib
+import traceback
+import threading
+import subprocess
 
 
 if importlib.util.find_spec("PySide2"):
@@ -26,38 +29,122 @@ else:
 # setup logging
 from ftrack_logging import configure_logging
 
-configure_logging('ftrack_rv')
-logger = logging.getLogger('ftrack_rv')
+configure_logging("ftrack_rv")
+logger = logging.getLogger("ftrack_rv")
 
 # Setup dependencies path.
 dependencies_path = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'dependencies.zip')
+    os.path.join(os.path.dirname(__file__), "dependencies.zip")
 )
 
-logger.debug(f'Adding {dependencies_path} to PATH')
+logger.debug(f"Adding {dependencies_path} to PATH")
 sys.path.insert(0, dependencies_path)
 
 
+# import RV modules early so command-line flags can be consulted before
+# the rest of the plugin (and ftrack_rv_api's module-level session
+# construction) runs.
+import rv  # noqa: E402  ordering matters; see comment above
+from rv import commands as rvc  # noqa: E402
+from rv import extra_commands as rve  # noqa: E402
+from rv import qtutils as rvq  # noqa: E402
+
+
+# Captured plugin-initialization failure surfaced in the UI. Set by any
+# of the protected blocks below or by FtrackMode.__init__. Format:
+# ``(short_reason: str, details: str)`` where details is typically a
+# traceback. ``None`` means initialization succeeded so far.
+_init_error = None
+
+
+# Pre-import environment setup. When RV is launched via the rvlink://
+# protocol handler, FTRACK_SERVER is only present as a command-line
+# flag (ftrackUrl=...) and is not in os.environ -- so we must promote
+# it before ftrack_rv_api imports and tries to construct a session.
 try:
-    import ftrack_api
-    from ftrack_api.symbol import ORIGIN_LOCATION_ID, SERVER_LOCATION_ID
-except ImportError as error:
-    raise ImportError('Could not import ftrack api, aborting.')
+    _commandline_url = rvc.commandLineFlag("ftrackUrl", None)
+    if _commandline_url and not os.environ.get("FTRACK_SERVER"):
+        os.environ["FTRACK_SERVER"] = _commandline_url
 
-# import ftack_rv_api
-import ftrack_rv_api as fra
+    # Setup ssl certificate path.
+    _cacert_path = os.path.join(os.path.dirname(__file__), "cacert.pem")
+    os.environ["REQUESTS_CA_BUNDLE"] = _cacert_path
+except Exception:
+    logger.exception("Pre-import ftrack environment setup failed.")
+    _init_error = (
+        "Failed to set up the ftrack environment before module load.",
+        traceback.format_exc(),
+    )
 
-# import RV related modules
 
-import rv
-from rv import commands as rvc
-from rv import extra_commands as rve
-from rv import qtutils as rvq
+try:
+    import ftrack_api  # noqa: E402
+except ImportError:
+    logger.exception("Could not import ftrack_api.")
+    ftrack_api = None
+    if _init_error is None:
+        _init_error = (
+            "Could not load the ftrack API module. "
+            "The dependencies bundle may be missing or corrupt.",
+            traceback.format_exc(),
+        )
 
-import threading
-import subprocess
 
-mode_name = 'ftrack'
+# Import ftrack_rv_api. It captures its own session-construction failure
+# rather than raising, so the import itself only fails on genuine code
+# errors (syntax, missing deps).
+try:
+    import ftrack_rv_api as fra  # noqa: E402
+except Exception:
+    logger.exception("Could not import ftrack_rv_api.")
+    fra = None
+    if _init_error is None:
+        _init_error = (
+            "Could not load the ftrack API module. See traceback below.",
+            traceback.format_exc(),
+        )
+
+# If the module imported but its session failed to construct, surface
+# that as the panel error.
+if _init_error is None and fra is not None and fra.session is None:
+    _init_error = (
+        fra.session_init_reason or "Could not connect to the ftrack server.",
+        fra.session_init_error,
+    )
+
+mode_name = "ftrack"
+
+
+def _render_error_html(reason, details=None):
+    """Read the noserver template and substitute the reason and optional details.
+
+    When *details* is provided (typically a traceback), the page includes
+    a collapsible ``<details>`` block showing the full text. The reason
+    is always rendered as the primary message. Both inputs are HTML-
+    escaped.
+    """
+    template_path = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)),
+        "SupportFiles",
+        "ftrack",
+        "noserver.html",
+    )
+    with open(template_path, "r", encoding="utf-8") as fh:
+        template = fh.read()
+
+    if details:
+        details_block = (
+            "<details>"
+            "<summary>Show traceback</summary>"
+            f"<pre>{html.escape(details)}</pre>"
+            "</details>"
+        )
+    else:
+        details_block = ""
+
+    template = template.replace("{{REASON}}", html.escape(reason))
+    template = template.replace("{{DETAILS_BLOCK}}", details_block)
+    return template
 
 
 class Runner(threading.Thread):
@@ -124,15 +211,25 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Args:
             name (str): The name of the minor mode instance
         """
-        logger.debug('init')
+        logger.debug("init")
         rv.rvtypes.MinorMode.__init__(self)
 
         self._name = name
+        self._session = None
 
-        self.setup_variables()
-        self.check_envs()
-        self.create_session()
-        self.create_bindings()
+        global _init_error
+        try:
+            self.setup_variables()
+            self.check_envs()
+            self.create_session()
+            self.create_bindings()
+        except Exception:
+            logger.exception("FtrackMode initialization failed.")
+            if _init_error is None:
+                _init_error = (
+                    "ftrack plugin initialization failed.",
+                    traceback.format_exc(),
+                )
 
     @property
     def name(self):
@@ -146,39 +243,45 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
     def create_session(self):
         """
-        This method initializes the ftrack API session with auto-connect event hub disabled,
+        Initialize the ftrack API session with auto-connect event hub disabled.
+
+        If session construction fails the exception is captured into the
+        module-level ``_init_error`` so the panel can surface it; we do
+        not re-raise, which would prevent the mode from registering.
         """
-        self._session = ftrack_api.Session(auto_connect_event_hub=False)
+        global _init_error
+        if ftrack_api is None:
+            self._session = None
+            return
+        try:
+            self._session = ftrack_api.Session(auto_connect_event_hub=False)
+        except Exception as exception:
+            logger.exception("Failed to construct ftrack API session.")
+            self._session = None
+            if _init_error is None:
+                _init_error = (
+                    "Could not connect to the ftrack server. Verify "
+                    "FTRACK_SERVER and FTRACK_API_KEY are set (or pass "
+                    "ftrackUrl=... via rvlink), then restart RV. "
+                    f"({type(exception).__name__}: {exception})",
+                    traceback.format_exc(),
+                )
 
     def check_envs(self):
         """
-        Checks and sets up the required environment variables for Ftrack integration.
+        Log the resolved ftrack environment.
 
-        This method first checks if a command-line URL is provided. If not, it verifies
-        that the required environment variables (FTRACK_SERVER and FTRACK_API_KEY) are
-        present. If a command-line URL is provided, it sets the FTRACK_SERVER environment
-        variable to that URL. Additionally, it sets the REQUESTS_CA_BUNDLE environment
-        variable to point to the cacert.pem file located in the plugin directory.
-
-        Logs debug and info messages about the environment variables being checked and
-        set.
+        The actual env-var promotion (``ftrackUrl`` command-line flag to
+        ``FTRACK_SERVER``, ``REQUESTS_CA_BUNDLE`` to bundled cacert) now
+        happens at module top level so that the session in
+        ``ftrack_rv_api`` can be constructed without first instantiating
+        this mode. This method just logs the resolved state and warns if
+        any required variable is still missing.
         """
-        logger.debug('check_envs')
-        commandline_url = rvc.commandLineFlag('ftrackUrl', None)
-
-        logger.debug(f'command line url {commandline_url}')
-        if not commandline_url:
-            # Check for base environment presence.
-            required_envs = ['FTRACK_SERVER', 'FTRACK_API_KEY']
-            for env in required_envs:
-                if env not in os.environ:
-                    logger.error(f'{env} environment not found!')
-        else:
-            os.environ['FTRACK_SERVER'] = commandline_url
-
-        # Setup ssl certificate path.
-        cacert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
-        os.environ['REQUESTS_CA_BUNDLE'] = cacert_path
+        logger.debug("check_envs")
+        for env in ("FTRACK_SERVER", "FTRACK_API_KEY"):
+            if env not in os.environ:
+                logger.error(f"{env} environment not found!")
 
         logger.info(f'env FTRACK_SERVER: {os.getenv("FTRACK_SERVER")}')
         logger.info(f'env FTRACK_API_KEY: {os.getenv("FTRACK_API_KEY")}')
@@ -209,17 +312,30 @@ class FtrackMode(rv.rvtypes.MinorMode):
             - The URL is generated using the command line parameters
             - JavaScript export is enabled for the web page
         """
-        logger.debug('createActionWindow')
+        logger.debug("createActionWindow")
 
-        title = ''
+        title = ""
         startSize = 500
         showTitle = False
         if self._dockActionWidget:
             return
 
-        url = fra._generateURL(
-            rvc.commandLineFlag("params", None), "review_action"
-        )
+        # Same init-error handling as the navigation panel: surface
+        # captured failures via the error template rather than calling
+        # _generateURL when there's no usable session.
+        if _init_error is not None:
+            url = ""
+            reason, details = _init_error
+        elif fra is None:
+            url = ""
+            reason = "ftrack API module is not available."
+            details = None
+        else:
+            url, reason = fra._generateURL(
+                rvc.commandLineFlag("params", None), "review_action"
+            )
+            details = None
+
         self._dockActionWidget = QtWidgets.QDockWidget(
             title, self.mainWindow, QtCore.Qt.Widget
         )
@@ -235,7 +351,13 @@ class FtrackMode(rv.rvtypes.MinorMode):
             )
         )
 
-        self._webActionWidget.load(QtCore.QUrl(url))
+        if url:
+            self._webActionWidget.load(QtCore.QUrl(url))
+        else:
+            logger.info(f"action panel unavailable: {reason}")
+            self._webActionWidget.setHtml(
+                _render_error_html(reason, details=details)
+            )
         rvq.javascriptExport(self._webActionWidget.page())
         self._dockActionWidget.setWidget(self._baseActionWidget)
 
@@ -278,7 +400,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             QtWidgets.QWidget: A widget containing the QWebEngineView for displaying web content
         """
-        logger.debug('makeit')
+        logger.debug("makeit")
 
         form = QtWidgets.QWidget(self.mainWindow, QtCore.Qt.Widget)
         verticalLayout = QtWidgets.QVBoxLayout(form)
@@ -310,7 +432,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
             When called with event.contents() = "1", this method will create
             a floating dock widget for the first dock widget in the application.
         """
-        logger.debug('toggleFloating')
+        logger.debug("toggleFloating")
 
         index = int(event.contents())
 
@@ -343,7 +465,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Args:
             event: The event object that triggered the shutdown process
         """
-        logger.debug('shutdown')
+        logger.debug("shutdown")
         event.reject()
 
         if self._webNavigationWidget:
@@ -371,7 +493,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         """
         content = base64.b64decode(event.contents())
 
-        logger.debug(f'ftrackEvent {content}')
+        logger.debug(f"ftrackEvent {content}")
 
         jsContent = f'FT.updateFtrack("{event.contents()}")'
         logger.debug(jsContent)
@@ -402,7 +524,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             None
         """
-        logger.debug('toggleTitleBar')
+        logger.debug("toggleTitleBar")
 
         if not dockWidget.isFloating():
             dockWidget.setTitleBarWidget(QtWidgets.QWidget(self.mainWindow))
@@ -425,7 +547,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             None
         """
-        logger.debug('viewLoaded')
+        logger.debug("viewLoaded")
 
         view.setMaximumWidth(16777215)
         view.setMinimumWidth(0)
@@ -452,30 +574,35 @@ class FtrackMode(rv.rvtypes.MinorMode):
         if not self._firstRender:
             return
 
-        logger.debug('initUI')
+        logger.debug("initUI")
 
         self._firstRender = False
         showTitle = False
         startSize = 500
 
-        params = rvc.commandLineFlag("params", None)
-        url = fra._generateURL(params, 'review_navigation')
+        # If anything went wrong during plugin or session initialization
+        # we surface that here rather than calling into fra (which may
+        # not have a usable session).
+        if _init_error is not None:
+            url = ""
+            reason, details = _init_error
+            logger.info(f"navigation panel unavailable: {reason}")
+        elif fra is None:
+            url = ""
+            reason = "ftrack API module is not available."
+            details = None
+            logger.info(f"navigation panel unavailable: {reason}")
+        else:
+            params = rvc.commandLineFlag("params", None)
+            url, reason = fra._generateURL(params, "review_navigation")
+            details = None
 
-        if not url:
-            noServer = os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
-                "SupportFiles",
-                "ftrack",
-                'noserver.html',
-            )
-            urlPrefix = (
-                "file:///" if (platform.system() == "Windows") else "file://"
-            )
-            url = ''.join([urlPrefix, noServer]).replace('\\', '//')
+            if url:
+                logger.info(f"url: {url}")
+            else:
+                logger.info(f"navigation panel unavailable: {reason}")
 
-        logger.info(f'url: {url}')
-
-        title = ''
+        title = ""
         self._dockNavigationWidget = QtWidgets.QDockWidget(
             title, self.mainWindow, QtCore.Qt.Widget
         )
@@ -489,7 +616,12 @@ class FtrackMode(rv.rvtypes.MinorMode):
             lambda: self.view_loaded(self._baseNavigationWidget)
         )
 
-        self._webNavigationWidget.load(QtCore.QUrl(str(url)))
+        if url:
+            self._webNavigationWidget.load(QtCore.QUrl(str(url)))
+        else:
+            self._webNavigationWidget.setHtml(
+                _render_error_html(reason, details=details)
+            )
         rvq.javascriptExport(self._webNavigationWidget.page())
         self._dockNavigationWidget.setWidget(self._baseNavigationWidget)
 
@@ -540,12 +672,12 @@ class FtrackMode(rv.rvtypes.MinorMode):
             None
 
         """
-        logger.debug(f'FrameChanged | evt : {event}')
+        logger.debug(f"FrameChanged | evt : {event}")
 
         frame = rvc.sourcesAtFrame(rvc.frame())[0]
         source = int(re.match("[a-zA-Z]+([0-9]+)", frame).group(1))
         logger.debug(
-            f'FrameChanged | _currentSource : {self._currentSource} , source {source}'
+            f"FrameChanged | _currentSource : {self._currentSource} , source {source}"
         )
 
         if self._currentSource != source:
@@ -553,9 +685,9 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
             data = base64.b64encode(
                 json.dumps(
-                    {'type': 'changedGroup', 'index': str(_currentSource)}
+                    {"type": "changedGroup", "index": str(_currentSource)}
                 ).encode("utf-8")
-            ).decode('ascii')
+            ).decode("ascii")
 
             logger.debug(data)
             jsData = f'FT.updateFtrack("{data}")'
@@ -574,7 +706,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
             the view node to "sourceGroup00000group1".
 
         """
-        logger.debug(f'navGroupChanged {event}')
+        logger.debug(f"navGroupChanged {event}")
         self.setViewNode("sourceGroup00000" + event.contents())
 
     def ftrack_toggle(self, event):
@@ -591,7 +723,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             None
         """
-        logger.debug(f'ftrackToggle {event}')
+        logger.debug(f"ftrackToggle {event}")
 
         if self._isHidden:
             self._isHidden = False
@@ -615,7 +747,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
         Note: This method only hides the panels - it does not remove them from the UI.
         """
-        logger.debug(f'hidePanels')
+        logger.debug("hidePanels")
 
         if self._baseNavigationWidget:
             self._baseNavigationWidget.hide()
@@ -643,7 +775,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         This method is useful for restoring the user interface to a full-featured state
         after panels have been hidden or minimized.
         """
-        logger.debug(f'hidePanels')
+        logger.debug("hidePanels")
 
         if self._baseNavigationWidget:
             self._baseNavigationWidget.show()
@@ -670,7 +802,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             None
         """
-        logger.debug(f'showPanelsOnStartupToggle')
+        logger.debug("showPanelsOnStartupToggle")
 
         if not self._showPanelsOnStartup:
             rvc.writeSettings("ftrack", "showPanelsOnStartUp", True)
@@ -725,7 +857,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Also sets up a context menu with options to toggle panels and access
         preferences, including a setting to show panels on startup.
         """
-        logger.debug('create_bindings')
+        logger.debug("create_bindings")
 
         self._showPanelsOnStartup = rvc.readSettings(
             "ftrackMode", "showPanelsOnStartUp", True
@@ -856,7 +988,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         # This will cause the component to use the same filesystem path
         # during the entire session.
 
-        logger.debug('setup_variables')
+        logger.debug("setup_variables")
         self.mainWindow = rvq.sessionWindow()
         self._firstRender = True
         self._isHidden = False
@@ -896,9 +1028,9 @@ class FtrackMode(rv.rvtypes.MinorMode):
         Returns:
             None
         """
-        logger.debug(f'Uploading all annotated frames')
-        logger.debug(f'self._doUpload {self._doUpload}')
-        logger.debug(f'self._annotatedFrames {self._annotatedFrames}')
+        logger.debug("Uploading all annotated frames")
+        logger.debug(f"self._doUpload {self._doUpload}")
+        logger.debug(f"self._annotatedFrames {self._annotatedFrames}")
         for i, path in enumerate(self._doUpload):
             self.upload_annotation(path, i)
 
@@ -914,11 +1046,11 @@ class FtrackMode(rv.rvtypes.MinorMode):
             count (int): The current upload count to display in the Ftrack UI
 
         """
-        logger.debug(f'uploadingCount: {count}')
+        logger.debug(f"uploadingCount: {count}")
 
         data = base64.b64encode(
-            json.dumps({'type': 'uploadCount', 'count': count}).encode("utf-8")
-        ).decode('ascii')
+            json.dumps({"type": "uploadCount", "count": count}).encode("utf-8")
+        ).decode("ascii")
 
         self._webActionWidget.page().runJavaScript(
             f'FT.updateFtrack("{data}")'
@@ -961,16 +1093,16 @@ class FtrackMode(rv.rvtypes.MinorMode):
         - Error handling is assumed to be managed by the parent class or framework
         - The component ID is used for tracking and reference throughout the upload process
         """
-        logger.debug(f'uploading file : {filename}')
+        logger.debug(f"uploading file : {filename}")
 
-        encoded_args = json.dumps({'file_name': filename, 'frame': frame})
+        encoded_args = json.dumps({"file_name": filename, "frame": frame})
 
         component_id = fra.create_component(encoded_args)
-        logger.debug(f'created component : {component_id}')
+        logger.debug(f"created component : {component_id}")
         self.on_upload_started(component_id)
 
         fra.upload_component(component_id)
-        logger.debug(f'Upload completed')
+        logger.debug("Upload completed")
         self.on_upload_complete(component_id)
 
     def on_upload_started(self, component_id):
@@ -998,7 +1130,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
         """
         data_string = json.dumps(
-            {'type': 'uploadStarted', 'attachment': component_id}
+            {"type": "uploadStarted", "attachment": component_id}
         )
 
         self._update_ftrack(data_string)
@@ -1027,7 +1159,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
             - This method should only be called after a successful upload
               operation to ensure data consistency
         """
-        data_string = json.dumps({'type': 'uploadEnded', 'id': component_id})
+        data_string = json.dumps({"type": "uploadEnded", "id": component_id})
 
         self._update_ftrack(data_string)
 
@@ -1050,10 +1182,10 @@ class FtrackMode(rv.rvtypes.MinorMode):
             - The encoded data is passed to the Ftrack integration via JavaScript.
             - This method logs the data string for debugging purposes.
         """
-        logger.debug(f'_update_ftrack: {data_string}')
+        logger.debug(f"_update_ftrack: {data_string}")
 
-        data = data_string.encode('utf-8')
-        data = base64.b64encode(data).decode('ascii')
+        data = data_string.encode("utf-8")
+        data = base64.b64encode(data).decode("ascii")
         self._webActionWidget.page().runJavaScript(
             f'FT.updateFtrack("{data}")'
         )
@@ -1089,7 +1221,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         """
         _token = event.contents()
         _name = event.name()
-        logger.debug(f'ftrackExportAll: {_token} :: {_name}')
+        logger.debug(f"ftrackExportAll: {_token} :: {_name}")
 
         # Add all the frames and export
         # Generate filenames that are unique
@@ -1110,23 +1242,23 @@ class FtrackMode(rv.rvtypes.MinorMode):
             frames = rve.findAnnotatedFrames()
 
         self._annotatedFrames = frames
-        logger.debug(f'frames : {frames})')
+        logger.debug(f"frames : {frames})")
 
         for i in frames:
             tmpUpload.append(f"{_uuid}_{i:04d}.jpg")
 
-        session_name = os.path.join(_filePath, f'rvsession_{_uuid}.rv')
+        session_name = os.path.join(_filePath, f"rvsession_{_uuid}.rv")
 
         self._doUpload = tmpUpload
         tmpSession = rvc.saveSession(session_name, True)
-        logger.debug(f'tmpSession : {tmpSession}')
+        logger.debug(f"tmpSession : {tmpSession}")
 
         args = [
             session_name,
             "-o",
             f"{_filePath}/{_uuid}_#.jpg",
             "-t",
-            ','.join([str(f) for f in frames]),
+            ",".join([str(f) for f in frames]),
             "-overlay",
             "frameburn",
             "0.8",
@@ -1134,7 +1266,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
             "30.0",
         ]
 
-        logger.debug(f'rvsession args: {args}')
+        logger.debug(f"rvsession args: {args}")
 
         self.uploading_count(len(self._doUpload))
         if len(self._doUpload) > 0:
@@ -1167,11 +1299,11 @@ class FtrackMode(rv.rvtypes.MinorMode):
             The command includes -v for verbose output and -err-to-out to redirect error
             messages to standard output. The method logs the full command for debugging.
         """
-        rvioc = os.getenv('RV_APP_RVIO', 'rvio')
-        cmd = [rvioc, '-v', '-err-to-out']
-        license = os.getenv('RV_APP_USE_LICENSE_FILE')
+        rvioc = os.getenv("RV_APP_RVIO", "rvio")
+        cmd = [rvioc, "-v", "-err-to-out"]
+        license = os.getenv("RV_APP_USE_LICENSE_FILE")
         if license:
-            cmd.append('-lic', license)
+            cmd.append("-lic", license)
 
         cmd.extend(inargs)
         logger.debug(f'rvio cmd : {" ".join(cmd)}')
@@ -1179,7 +1311,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
         proc.start()
 
     def activate(self):
-        '''
+        """
         Activate the ftrack plugin in RV.
 
         This method is called when the plugin is first loaded in RV. It activates
@@ -1191,12 +1323,12 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
         Returns:
             None
-        '''
+        """
         rv.rvtypes.MinorMode.activate(self)
         self._dockNavigationWidget.show()
 
     def deactivate(self):
-        '''
+        """
         Deactivate the ftrack plugin in RV.
 
         This method is called when the plugin is being unloaded or deactivated.
@@ -1206,7 +1338,7 @@ class FtrackMode(rv.rvtypes.MinorMode):
 
         Returns:
             None
-        '''
+        """
         rv.rvtypes.MinorMode.deactivate(self)
         self._dockNavigationWidget.hide()
 

--- a/projects/rv/resource/plugin/ftrack_rv_api.py
+++ b/projects/rv/resource/plugin/ftrack_rv_api.py
@@ -13,13 +13,12 @@ from uuid import uuid1 as uuid
 import logging
 
 
-import rv
 from rv import commands as rvc
 from rv import extra_commands as rve
 from rv import runtime as rvr
 
 
-ftrack_rv_logger_name = 'ftrack_rv'
+ftrack_rv_logger_name = "ftrack_rv"
 
 
 try:
@@ -28,31 +27,31 @@ try:
     ftrack_logging.configure_logging(ftrack_rv_logger_name)
     # Setup logging.
 except Exception as error:
-    logging.warning('Failed to Initialize logging.', error)
+    logging.warning("Failed to Initialize logging.", error)
 
 logger = logging.getLogger(ftrack_rv_logger_name)
 logger.debug(f'PY3 Enabled: {os.environ.get("RV_PYTHON3", "NOT SET")}')
-logger.debug(f'Interpreter {sys.executable}')
-logger.debug(f'version {sys.version_info}')
+logger.debug(f"Interpreter {sys.executable}")
+logger.debug(f"version {sys.version_info}")
 
 
 # Check for base environment presence.
-required_envs = ['FTRACK_SERVER', 'FTRACK_API_KEY']
+required_envs = ["FTRACK_SERVER", "FTRACK_API_KEY"]
 for env in required_envs:
     if env not in os.environ:
-        logger.error(f'{env} environment not found!')
+        logger.error(f"{env} environment not found!")
 
 
 # Setup ssl certificate path.
-cacert_path = os.path.join(os.path.dirname(__file__), 'cacert.pem')
-os.environ['REQUESTS_CA_BUNDLE'] = cacert_path
+cacert_path = os.path.join(os.path.dirname(__file__), "cacert.pem")
+os.environ["REQUESTS_CA_BUNDLE"] = cacert_path
 
 # Setup dependencies path.
 dependencies_path = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), 'dependencies.zip')
+    os.path.join(os.path.dirname(__file__), "dependencies.zip")
 )
 
-logger.debug(f'Adding {dependencies_path} to PATH')
+logger.debug(f"Adding {dependencies_path} to PATH")
 sys.path.insert(0, dependencies_path)
 
 
@@ -61,8 +60,8 @@ try:
     import ftrack_api
     from ftrack_api.symbol import ORIGIN_LOCATION_ID, SERVER_LOCATION_ID
 
-except ImportError as e:
-    logger.error(f'No Ftrack API module found in {dependencies_path}')
+except ImportError:
+    logger.error(f"No Ftrack API module found in {dependencies_path}")
     raise
 
 
@@ -79,20 +78,35 @@ layoutSourceNode = None
 annotation_components = {}
 
 
-# Initialize New API
+# Initialize New API. Failures are captured so the module still imports;
+# callers (see ftrack.py) check ``session is None`` / ``session_init_error``
+# and render an error panel instead of crashing the plugin.
+session = None
+origin_location = None
+server_location = None
+session_init_error = ""
+session_init_reason = ""
 try:
     session = ftrack_api.Session(auto_connect_event_hub=False)
 
     # Get some useful locations.
-    origin_location = session.get('Location', ORIGIN_LOCATION_ID)
-    server_location = session.get('Location', SERVER_LOCATION_ID)
+    origin_location = session.get("Location", ORIGIN_LOCATION_ID)
+    server_location = session.get("Location", SERVER_LOCATION_ID)
 
-except Exception as e:
-    logger.error(e)
-    raise
+except Exception as exception:
+    logger.exception("Failed to initialize ftrack API session.")
+    session = None
+    origin_location = None
+    server_location = None
+    session_init_error = traceback.format_exc()
+    session_init_reason = (
+        "Could not connect to the ftrack server. Verify FTRACK_SERVER "
+        "and FTRACK_API_KEY are set (or pass ftrackUrl=... via rvlink), "
+        f"then restart RV. ({type(exception).__name__}: {exception})"
+    )
 
 
-def _getSourceNode(nodeType='sequence'):
+def _getSourceNode(nodeType="sequence"):
     """
     Return the source node of the specified type (sequence, stack, or layout).
 
@@ -113,27 +127,27 @@ def _getSourceNode(nodeType='sequence'):
     global stackSourceNode
     global layoutSourceNode
 
-    if nodeType == 'sequence':
+    if nodeType == "sequence":
         if sequenceSourceNode is None:
-            sequenceSourceNode = rvc.newNode('RVSequenceGroup', 'Sequence')
+            sequenceSourceNode = rvc.newNode("RVSequenceGroup", "Sequence")
 
-            rve.setUIName(sequenceSourceNode, 'SequenceNode')
+            rve.setUIName(sequenceSourceNode, "SequenceNode")
 
         return sequenceSourceNode
 
-    elif nodeType == 'stack':
+    elif nodeType == "stack":
         if stackSourceNode is None:
-            stackSourceNode = rvc.newNode('RVStackGroup', 'Stack')
+            stackSourceNode = rvc.newNode("RVStackGroup", "Stack")
 
-            rve.setUIName(stackSourceNode, 'StackNode')
+            rve.setUIName(stackSourceNode, "StackNode")
 
         return stackSourceNode
 
-    elif nodeType == 'layout':
+    elif nodeType == "layout":
         if layoutSourceNode is None:
-            layoutSourceNode = rvc.newNode('RVLayoutGroup', 'Layout')
+            layoutSourceNode = rvc.newNode("RVLayoutGroup", "Layout")
 
-            rve.setUIName(layoutSourceNode, 'LayoutNode')
+            rve.setUIName(layoutSourceNode, "LayoutNode")
 
         return layoutSourceNode
 
@@ -151,11 +165,11 @@ def _setWipeMode(state):
     Returns:
         None
     """
-    if rvr.eval('rvui.wipeShown()', ['rvui']) != -1 and state is False:
-        rvr.eval('rvui.toggleWipe()', ['rvui'])
+    if rvr.eval("rvui.wipeShown()", ["rvui"]) != -1 and state is False:
+        rvr.eval("rvui.toggleWipe()", ["rvui"])
 
-    if rvr.eval('rvui.wipeShown()', ['rvui']) == -1 and state is True:
-        rvr.eval('rvui.toggleWipe()', ['rvui'])
+    if rvr.eval("rvui.wipeShown()", ["rvui"]) == -1 and state is True:
+        rvr.eval("rvui.toggleWipe()", ["rvui"])
 
 
 def _getFilePath(componentId):
@@ -176,13 +190,13 @@ def _getFilePath(componentId):
     """
     global componentFilesystemPaths
     path = componentFilesystemPaths.get(componentId, None)
-    logger.debug(f'_getFilePath {componentId} :: {path}')
+    logger.debug(f"_getFilePath {componentId} :: {path}")
 
     if path is None:
-        ftrack_component = session.get('Component', componentId)
+        ftrack_component = session.get("Component", componentId)
         location = session.pick_location(component=ftrack_component)
         path = location.get_filesystem_path(ftrack_component)
-        logger.debug(f'adding {componentId} to {componentFilesystemPaths}')
+        logger.debug(f"adding {componentId} to {componentFilesystemPaths}")
         componentFilesystemPaths[componentId] = path
 
     return path
@@ -256,19 +270,19 @@ def loadPlaylist(playlist, index=None, includeFrame=None):
     _setWipeMode(False)
     startFrame = 1
 
-    if not includeFrame == 'false':
+    if not includeFrame == "false":
         startFrame = rve.sourceFrame(rvc.frame(), None)
 
-    for oldSource in rvc.nodesOfType('RVSourceGroup'):
+    for oldSource in rvc.nodesOfType("RVSourceGroup"):
         rvc.deleteNode(oldSource)
 
     sources = []
     for item in playlist:
-        sources.append(_getFilePath(item.get('componentId')))
+        sources.append(_getFilePath(item.get("componentId")))
 
-    sequenceSourceNode = _getSourceNode('sequence')
+    sequenceSourceNode = _getSourceNode("sequence")
 
-    _ftrackCreateGroup(sources, sequenceSourceNode, 'defaultLayout')
+    _ftrackCreateGroup(sources, sequenceSourceNode, "defaultLayout")
     rvc.setViewNode(sequenceSourceNode)
 
     if index:
@@ -298,16 +312,16 @@ def validateComponentLocation(componentId, versionId):
         )
         try:
             rvc.sendInternalEvent(
-                'ftrack-event',
+                "ftrack-event",
                 base64.b64encode(
                     json.dumps(
-                        {'type': 'breakItem', 'versionId': versionId}
+                        {"type": "breakItem", "versionId": versionId}
                     ).encode("utf-8")
-                ).decode('ascii'),
+                ).decode("ascii"),
                 None,
             )
         except Exception:
-            logger.error('Could not send internal event to ftrack.')
+            logger.error("Could not send internal event to ftrack.")
 
 
 def ftrackCompare(data):
@@ -332,31 +346,31 @@ def ftrackCompare(data):
     except Exception:
         pass
 
-    componentIdA = data.get('componentIdA')
-    componentIdB = data.get('componentIdB')
-    mode = data.get('mode')
+    componentIdA = data.get("componentIdA")
+    componentIdB = data.get("componentIdB")
+    mode = data.get("mode")
 
     trackA = _getFilePath(componentIdA)
 
-    layout = 'defaultStack' if mode == 'wipe' else 'defaultLayout'
+    layout = "defaultStack" if mode == "wipe" else "defaultLayout"
 
-    if not mode == 'load':
+    if not mode == "load":
         trackB = _getFilePath(componentIdB)
 
         try:
-            if mode == 'wipe':
-                sourceNode = _getSourceNode('stack')
+            if mode == "wipe":
+                sourceNode = _getSourceNode("stack")
                 _ftrackCreateGroup([trackA, trackB], sourceNode, layout)
                 rvc.setViewNode(sourceNode)
-                rvr.eval('rvui.toggleWipe()', ['rvui'])
+                rvr.eval("rvui.toggleWipe()", ["rvui"])
             else:
-                sourceNode = _getSourceNode('layout')
+                sourceNode = _getSourceNode("layout")
                 _ftrackCreateGroup([trackA, trackB], sourceNode, layout)
                 rvc.setViewNode(sourceNode)
         except Exception:
             print(traceback.format_exc())
     else:
-        sourceNode = _getSourceNode('layout')
+        sourceNode = _getSourceNode("layout")
         _ftrackCreateGroup([trackA], sourceNode, layout)
         rvc.setViewNode(sourceNode)
 
@@ -376,7 +390,7 @@ def _getEntityFromEnvironment():
     """
     # Check for environment variable specifying additional information to
     # use when loading.
-    eventEnvironmentVariable = 'FTRACK_CONNECT_EVENT'
+    eventEnvironmentVariable = "FTRACK_CONNECT_EVENT"
 
     eventData = os.environ.get(eventEnvironmentVariable)
 
@@ -385,26 +399,26 @@ def _getEntityFromEnvironment():
             decodedEventData = json.loads(base64.b64decode(eventData))
         except (TypeError, ValueError):
             logger.error(
-                f'Failed to decode {eventEnvironmentVariable}: {eventData}'
+                f"Failed to decode {eventEnvironmentVariable}: {eventData}"
             )
         else:
-            selection = decodedEventData.get('selection', [])
-            logger.info(f'selection {selection}')
+            selection = decodedEventData.get("selection", [])
+            logger.info(f"selection {selection}")
             # At present only a single entity which should represent an
             # ftrack List is supported.
             if selection:
                 try:
                     entity = selection[0]
-                    entityId = entity.get('entityId')
-                    entityType = entity.get('entityType')
+                    entityId = entity.get("entityId")
+                    entityType = entity.get("entityType")
                     return entityId, entityType
                 except (IndexError, AttributeError, KeyError):
                     logger.error(
-                        f'Failed to extract selection information from: {selection}'
+                        f"Failed to extract selection information from: {selection}"
                     )
     else:
         logger.debug(
-            f'No event data retrieved. {eventEnvironmentVariable} not set.'
+            f"No event data retrieved. {eventEnvironmentVariable} not set."
         )
 
     return None, None
@@ -414,30 +428,22 @@ def getNavigationURL(params=None):
     """
     Return URL to navigation panel in ftrack.
 
-    This method generates a URL to the navigation panel based on provided parameters.
-
-    Args:
-        params (dict, optional): Parameters to use for generating the URL. Defaults to None.
-
-    Returns:
-        str: URL to the navigation panel.
+    Returns an empty string when no URL can be generated. Use
+    :func:`_generateURL` directly when you also need the failure reason.
     """
-    return _generateURL(params, 'review_navigation')
+    url, _reason = _generateURL(params, "review_navigation")
+    return url
 
 
 def getActionURL(params=None):
     """
     Return URL to action panel in ftrack.
 
-    This method generates a URL to the action panel based on provided parameters.
-
-    Args:
-        params (dict, optional): Parameters to use for generating the URL. Defaults to None.
-
-    Returns:
-        str: URL to the action panel.
+    Returns an empty string when no URL can be generated. Use
+    :func:`_generateURL` directly when you also need the failure reason.
     """
-    return _generateURL(params, 'review_action')
+    url, _reason = _generateURL(params, "review_action")
+    return url
 
 
 def _translateEntityType(entityType):
@@ -459,23 +465,23 @@ def _translateEntityType(entityType):
     """
     # Get entity type and make sure it is lower cased. Most places except
     # the component tab in the Sidebar will use lower case notation.
-    entity_type = entityType.replace('_', '').lower()
+    entity_type = entityType.replace("_", "").lower()
 
     for schema in session.schemas:
-        alias_for = schema.get('alias_for')
+        alias_for = schema.get("alias_for")
 
         if (
             alias_for
             and isinstance(alias_for, str)
             and alias_for.lower() == entity_type
         ):
-            return schema['id']
+            return schema["id"]
 
     for schema in session.schemas:
-        if schema['id'].lower() == entity_type:
-            return schema['id']
+        if schema["id"].lower() == entity_type:
+            return schema["id"]
 
-    raise ValueError(f'Unable to translate entity type: {entity_type}.')
+    raise ValueError(f"Unable to translate entity type: {entity_type}.")
 
 
 def _get_temp_data_url(name, temp_data_id):
@@ -492,14 +498,14 @@ def _get_temp_data_url(name, temp_data_id):
         str: Full URL with entityType and entityId parameters.
     """
     operation = {
-        'action': 'get_widget_url',
-        'name': name,
-        'theme': None,
+        "action": "get_widget_url",
+        "name": name,
+        "theme": None,
     }
 
     result = session.call([operation])
-    url = result[0]['widget_url']
-    full_url = f'{url}&entityType=tempdata&entityId={temp_data_id}'
+    url = result[0]["widget_url"]
+    full_url = f"{url}&entityType=tempdata&entityId={temp_data_id}"
     return full_url
 
 
@@ -507,51 +513,92 @@ def _generateURL(params=None, panelName=None):
     """
     Generate a URL to a ftrack panel based on parameters.
 
-    This method creates a URL to a ftrack panel (navigation or action) based on
-    provided parameters or environment data.
-
     Args:
-        params (dict, optional): Parameters to use for generating the URL. Defaults to None.
-        panelName (str, optional): Name of the panel to generate URL for. Defaults to None.
+        params: Parameters string (JSON) to use for generating the URL.
+        panelName: Name of the panel to generate URL for.
 
     Returns:
-        str: URL to the ftrack panel.
+        tuple[str, str]: ``(url, reason)``. ``url`` is the resolved panel URL,
+        or an empty string when no URL could be generated. When ``url`` is
+        empty, ``reason`` is a human-readable explanation that callers can
+        surface in the UI; otherwise ``reason`` is empty.
     """
-    logger.info(f'_generateURL with params: {params}')
-    url = ''
+    logger.info(f"_generateURL with params: {params}")
+    if session is None:
+        return "", session_init_reason
+    url = ""
+    reason = ""
     try:
         entityId = None
         entityType = None
+        context_provided = bool(params) or bool(
+            os.environ.get("FTRACK_CONNECT_EVENT")
+        )
 
         if params:
             panelName = panelName or params
             try:
                 params = json.loads(params)
-                entityId = params['entityId'][0]
-                entityType = params['entityType'][0]
+                entityId = params["entityId"][0]
+                entityType = params["entityType"][0]
             except Exception:
                 entityId, entityType = _getEntityFromEnvironment()
+        else:
+            entityId, entityType = _getEntityFromEnvironment()
 
-            if entityId and entityType:
-                if entityType != 'tempdata':
-                    new_entity_type = _translateEntityType(entityType)
-                    new_entity = session.get(new_entity_type, entityId)
-                    try:
-                        url = session.get_widget_url(
-                            panelName, entity=new_entity
-                        )
-                    except Exception as exception:
-                        logger.error(str(exception))
-                else:
-                    try:
-                        url = _get_temp_data_url(panelName, entityId)
-                    except Exception as exception:
-                        logger.error(str(exception))
+        if not (entityId and entityType):
+            if context_provided:
+                reason = (
+                    "A launch context was provided but did not contain a "
+                    "valid entity selection. See the ftrack-rv log for "
+                    "details."
+                )
+            else:
+                reason = (
+                    "No entity selection was provided. Launch RV from "
+                    "ftrack Connect with a Task, AssetVersion, or List "
+                    "selected, or open a review link from the ftrack web "
+                    "UI via the rvlink:// protocol handler."
+                )
+        elif entityType != "tempdata":
+            new_entity = None
+            try:
+                new_entity_type = _translateEntityType(entityType)
+                new_entity = session.get(new_entity_type, entityId)
+            except Exception as exception:
+                logger.error(str(exception))
+                reason = (
+                    f'Failed to look up {entityType} {entityId} on '
+                    f'{os.environ.get("FTRACK_SERVER", "the ftrack server")}: '
+                    f'{exception}'
+                )
 
-        logger.info(f'Returning url "{url}"')
+            if new_entity is None and not reason:
+                reason = (
+                    f'Could not find {entityType} with id {entityId} on '
+                    f'{os.environ.get("FTRACK_SERVER", "the ftrack server")}.'
+                )
+            elif new_entity is not None:
+                try:
+                    url = session.get_widget_url(panelName, entity=new_entity)
+                except Exception as exception:
+                    logger.error(str(exception))
+                    reason = (
+                        f"ftrack returned an error while fetching the "
+                        f"{panelName} panel URL: {exception}"
+                    )
+        else:
+            try:
+                url = _get_temp_data_url(panelName, entityId)
+            except Exception as exception:
+                logger.error(str(exception))
+                reason = f"Failed to load temporary data panel: {exception}"
+
+        logger.info(f'Returning url "{url}" reason "{reason}"')
     except Exception as error:
-        logger.exception(f'Failed to generate URL. {error}')
-    return url
+        logger.exception(f"Failed to generate URL. {error}")
+        reason = f"Unexpected error generating URL: {error}"
+    return url, reason
 
 
 def ftrackFilePath(id):
@@ -574,8 +621,8 @@ def ftrackFilePath(id):
             filepath = tempfile.gettempdir()
         return filepath
     except Exception:
-        logger.exception('Failed to get file path.')
-        return ''
+        logger.exception("Failed to get file path.")
+        return ""
 
 
 def ftrackUUID():
@@ -608,16 +655,16 @@ def ftrackJumpTo(index=0, startFrame=1):
         index = int(index)
         frameNumber = 0
 
-        for idx, source in enumerate(rvc.nodesOfType('RVFileSource')):
+        for idx, source in enumerate(rvc.nodesOfType("RVFileSource")):
             if not idx >= index:
                 data = rvc.sourceMediaInfoList(source)[0]
-                add = (data.get('endFrame', 0) - data.get('startFrame', 0)) + 1
+                add = (data.get("endFrame", 0) - data.get("startFrame", 0)) + 1
                 add = 1 if add == 0 else add
                 frameNumber += add
 
         rvc.setFrame(frameNumber + startFrame)
     except Exception:
-        logger.exception('Failed to jump to index.')
+        logger.exception("Failed to jump to index.")
 
 
 def create_component(encoded_args):
@@ -644,19 +691,19 @@ def create_component(encoded_args):
     component_id = None
     try:
         args = json.loads(encoded_args)
-        file_name = args['file_name']
-        frame = args['frame']
+        file_name = args["file_name"]
+        frame = args["frame"]
 
-        component_name = f'Frame_{frame}'
-        file_path = os.path.join(ftrackFilePath(''), file_name)
-        logger.info(fr'Creating component: {file_path}')
+        component_name = f"Frame_{frame}"
+        file_path = os.path.join(ftrackFilePath(""), file_name)
+        logger.info(rf"Creating component: {file_path}")
         component = session.create_component(
             path=file_path, data=dict(name=component_name), location=None
         )
-        component_id = component['id']
+        component_id = component["id"]
         annotation_components[component_id] = component
     except Exception:
-        logger.exception('Failed to create component.')
+        logger.exception("Failed to create component.")
 
     return component_id
 
@@ -682,12 +729,12 @@ def upload_component(component_id):
     """
     try:
         logger.info(
-            f'Adding component {component_id} to ftrack server location.'
+            f"Adding component {component_id} to ftrack server location."
         )
         component = annotation_components[component_id]
         server_location.add_component(component, origin_location)
         del annotation_components[component_id]
     except Exception:
-        logger.exception('Failed to upload component')
+        logger.exception("Failed to upload component")
     else:
         return component_id

--- a/projects/rv/resource/plugin/noserver.html
+++ b/projects/rv/resource/plugin/noserver.html
@@ -1,27 +1,70 @@
 <!DOCTYPE html>
+<html>
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-        <title>No ftrack server found</title>
+        <title>ftrack review panel unavailable</title>
         <style>
+            body {
+                background: #2b2b2b;
+                color: #ddd;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                             Helvetica, Arial, sans-serif;
+                margin: 0;
+            }
             section {
-                margin: 0 auto;
-                width: 650px;
+                margin: 40px auto;
+                max-width: 720px;
+                padding: 0 24px;
+                text-align: center;
             }
             h1 {
-                text-align: center;
                 color: #b94a48;
+                font-size: 22px;
+                margin-bottom: 16px;
             }
-            p {
-                text-align: center;
+            #reason {
                 color: #ddd;
+                font-size: 14px;
+                line-height: 1.5;
+            }
+            details {
+                background: #1f1f1f;
+                border: 1px solid #444;
+                border-radius: 4px;
+                margin-top: 20px;
+                padding: 8px 12px;
+                text-align: left;
+            }
+            summary {
+                color: #ccc;
+                cursor: pointer;
+                font-size: 13px;
+                outline: none;
+            }
+            details pre {
+                color: #c9c9c9;
+                font-family: Menlo, Consolas, "Liberation Mono", monospace;
+                font-size: 12px;
+                line-height: 1.4;
+                margin: 8px 0 0 0;
+                overflow-x: auto;
+                white-space: pre-wrap;
+                word-break: break-word;
+            }
+            .hint {
+                color: #888;
+                font-size: 12px;
+                margin-top: 24px;
             }
         </style>
     </head>
     <body>
         <section>
-            <h1>Could not locate your ftrack server</h1>
-            <p>Please set your FTRACK_SERVER environment variable<br />or start ftrackreview for RV from ftrack</p>
+            <h1>ftrack review panel unavailable</h1>
+            <p id="reason">{{REASON}}</p>
+            {{DETAILS_BLOCK}}
+            <p class="hint">See the ftrack-rv log for more details.</p>
         </section>
     </body>
 </html>


### PR DESCRIPTION
The bottom ftrack dock panel had two related failure modes:

- When launched via the rvlink:// protocol handler (or directly without FTRACK_API_KEY in env), ftrack_rv_api raised at module load while constructing an ftrack_api.Session, causing the whole mode to fail to import. RV silently dropped the plugin and the panel never appeared -- even the existing fallback page was unreachable.
- For any URL-generation failure, including the common "no entity selection" case, the panel showed a static "Could not locate your ftrack server" page, misleading users into thinking the server was unreachable when it was just missing context. The env-var fallback in _generateURL only ran when params parsing failed, never when params was None (which happens whenever ftrackUrl is not passed via rvlink), so FTRACK_CONNECT_EVENT was never consulted.

This change makes plugin initialization robust and the fallback page honest:

- Promote the ftrackUrl command-line flag to FTRACK_SERVER before ftrack_rv_api imports, so rvlink launches can construct a session when an API key is also present.
- Wrap session construction in ftrack_rv_api in try/except; capture the traceback in session_init_error / session_init_reason and let the module import succeed regardless.
- Wrap the ftrack_api and ftrack_rv_api imports plus FtrackMode.__init__ in ftrack.py, populating a module-level _init_error tuple on any failure. The mode always registers; initialize_ui and create_action_window check _init_error before calling _generateURL.
- Change _generateURL to return (url, reason) with case-specific messages (no entity context including rvlink/Connect guidance, lookup failed, widget URL failed, session unavailable, etc.) and ensure the env-var fallback runs when params is None.
- Convert noserver.html into a template with {{REASON}} plus an optional {{DETAILS_BLOCK}} for a collapsible traceback. The panels render the template via QWebEngineView.setHtml() when no URL is available, so any captured error shows a specific reason and (when applicable) an expandable traceback instead of the misleading "no server" copy or nothing at all.
