### PR TITLE
fix: macos example plist for setting UI app env vars

### DIFF
--- a/projects/rv/config/macos/com.ftrack.rv.plist
+++ b/projects/rv/config/macos/com.ftrack.rv.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ftrack.rv</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>launchctl setenv FTRACK_SERVER "YOUR_SERVER_URL"
+launchctl setenv FTRACK_API_USER "YOUR_API_USERNAME"
+launchctl setenv FTRACK_API_KEY "YOUR_API_KEY"</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
fix example env var setup on osx