### PR TITLE
fix: Double session initialization

### DIFF
--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -13,6 +13,8 @@ from operator import itemgetter
 import time
 import qtawesome as qta
 
+from packaging.version import parse as parse_version, InvalidVersion
+
 import ftrack_api
 import ftrack_api._centralized_storage_scenario
 import ftrack_api.event.base
@@ -218,10 +220,12 @@ class Application(QtWidgets.QMainWindow):
         """restart connect application"""
         self.logger.info("Connect restarting....")
         QtWidgets.QApplication.quit()
-        self._instance.__del__()
+        if self._instance is not None:
+            self._instance.__del__()
 
         # Give enough time to ensure the lockfile has been removed
-        while os.path.exists(self._instance.lockfile):
+        lockfile = getattr(self._instance, "lockfile", None)
+        while lockfile and os.path.exists(lockfile):
             time.sleep(0.1)
         process = QtCore.QProcess()
 
@@ -447,7 +451,7 @@ class Application(QtWidgets.QMainWindow):
     def _show_login_widget(self):
         """Show the login widget."""
         self._login_overlay = ftrack_connect.ui.widget.overlay.CancelOverlay(
-            self._login_widget, message="<h2>Signing in<h2/>"
+            self._login_widget, message="<h2>Signing in</h2>"
         )
 
         self._login_overlay.hide()
@@ -651,7 +655,7 @@ class Application(QtWidgets.QMainWindow):
                 self.logger.exception("Failed to disconnect from event hub.")
                 pass
 
-        # NEW: Properly close the existing session before creating a new one
+        # Close the existing session before creating a new one.
         if self._session is not None:
             try:
                 self.logger.debug(
@@ -794,10 +798,18 @@ class Application(QtWidgets.QMainWindow):
                             not plugin["incompatible"]
                             and not plugin["deprecated"]
                         ):
-                            if (
-                                current_dir_plugin["version"]
-                                < plugin["version"]
-                            ):
+                            try:
+                                is_newer = parse_version(
+                                    current_dir_plugin["version"]
+                                ) < parse_version(plugin["version"])
+                            except InvalidVersion:
+                                # Non PEP 440 versions can't be parsed,
+                                # fall back to lexical comparison.
+                                is_newer = (
+                                    current_dir_plugin["version"]
+                                    < plugin["version"]
+                                )
+                            if is_newer:
                                 current_dir_plugins.remove(current_dir_plugin)
                                 break
                         found = True
@@ -1072,7 +1084,7 @@ class Application(QtWidgets.QMainWindow):
             )
 
         # Provide information from builtin widget plugins.
-        for plugin in self._widget_plugin_instances:
+        for plugin in self._widget_plugin_instances.values():
             if isinstance(plugin, ConnectWidget):
                 debug_information["widgets"].append(
                     plugin.get_debug_information()

--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -62,13 +62,13 @@ from ftrack_connect.utils.plugin import create_target_plugin_directory
 
 
 class ConnectWidgetPlugin(object):
-    topic = 'ftrack.connect.plugin.connect-widget'
+    topic = "ftrack.connect.plugin.connect-widget"
 
     def __init__(self, connect_widget):
-        '''Initialise class with non initialised connect_widget.'''
+        """Initialise class with non initialised connect_widget."""
         if not isinstance(connect_widget, type):
             raise Exception(
-                'Widget class {} should be non initialised'.format(
+                "Widget class {} should be non initialised".format(
                     connect_widget
                 )
             )
@@ -76,14 +76,13 @@ class ConnectWidgetPlugin(object):
         self._connect_widget = connect_widget
 
     def _return_widget(self, event):
-        '''Return stored widget class.'''
+        """Return stored widget class."""
         return self._connect_widget
 
     def register(self, session, priority):
-        '''register a new connect widget with given **priority**.'''
+        """register a new connect widget with given **priority**."""
         session.event_hub.subscribe(
-            'topic={0} '
-            'and source.user.username={1}'.format(
+            "topic={0} " "and source.user.username={1}".format(
                 self.topic, session.api_user
             ),
             self._return_widget,
@@ -92,7 +91,7 @@ class ConnectWidgetPlugin(object):
 
 
 class ConnectWidget(QtWidgets.QWidget):
-    '''Base widget for ftrack connect application plugin.'''
+    """Base widget for ftrack connect application plugin."""
 
     icon = None
     name = None
@@ -111,36 +110,36 @@ class ConnectWidget(QtWidgets.QWidget):
 
     @property
     def session(self):
-        '''Return current session.'''
+        """Return current session."""
         return self._session
 
     def __init__(self, session, parent=None):
-        '''Initialise class with ftrack *session* and *parent* widget.'''
+        """Initialise class with ftrack *session* and *parent* widget."""
         super(ConnectWidget, self).__init__(parent=parent)
         self._session = session
 
     def getName(self):
-        '''Return name of widget.'''
+        """Return name of widget."""
         return self.name or self.__class__.__name__
 
     def getIdentifier(self):
-        '''Return identifier for widget.'''
-        return self.getName().lower().replace(' ', '.')
+        """Return identifier for widget."""
+        return self.getName().lower().replace(" ", ".")
 
     def refresh(self):
-        '''Refresh/rebuild widget, called when widget has been fully set up. Should be overridden'''
+        """Refresh/rebuild widget, called when widget has been fully set up. Should be overridden"""
         pass
 
     def get_debug_information(self):
-        '''Return debug information for about dialog, should be overriden.'''
+        """Return debug information for about dialog, should be overriden."""
         return {
-            'name': self.getName(),
-            'identifier': self.getIdentifier(),
+            "name": self.getName(),
+            "identifier": self.getIdentifier(),
         }
 
 
 class Application(QtWidgets.QMainWindow):
-    '''Main application window for ftrack connect.'''
+    """Main application window for ftrack connect."""
 
     #: Signal when login fails.
     loginError = QtCore.Signal(object)
@@ -157,19 +156,19 @@ class Application(QtWidgets.QMainWindow):
 
     @property
     def session(self):
-        '''Return current session.'''
+        """Return current session."""
         return self._session
 
     @property
     def plugins(self):
         return self._plugins
 
-    def __init__(self, theme='system', instance=None, log_level=None):
-        '''Initialise the main application window with *theme*, singleton
-        *instance* and custom *log_level*.'''
+    def __init__(self, theme="system", instance=None, log_level=None):
+        """Initialise the main application window with *theme*, singleton
+        *instance* and custom *log_level*."""
         super(Application, self).__init__()
         self.logger = logging.getLogger(
-            __name__ + '.' + self.__class__.__name__
+            __name__ + "." + self.__class__.__name__
         )
         self._instance = instance
         self._session = None
@@ -191,10 +190,10 @@ class Application(QtWidgets.QMainWindow):
         if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
             QtWidgets.QMessageBox.warning(
                 self,
-                'Connect',
-                'No system tray located.\n\nHint: On '
-                'Linux CentOS consider installing '
-                'gnome-shell-extension-top-icons',
+                "Connect",
+                "No system tray located.\n\nHint: On "
+                "Linux CentOS consider installing "
+                "gnome-shell-extension-top-icons",
             )
         else:
             self._initialise_tray()
@@ -204,8 +203,8 @@ class Application(QtWidgets.QMainWindow):
 
         self._application_launcher = None
 
-        self.setObjectName('ftrack-connect-window')
-        self.setWindowTitle('ftrack Connect')
+        self.setObjectName("ftrack-connect-window")
+        self.setWindowTitle("ftrack Connect")
         self.resize(450, 700)
         self.move(50, 50)
 
@@ -216,8 +215,8 @@ class Application(QtWidgets.QMainWindow):
         self.login()
 
     def restart(self):
-        '''restart connect application'''
-        self.logger.info('Connect restarting....')
+        """restart connect application"""
+        self.logger.info("Connect restarting....")
         QtWidgets.QApplication.quit()
         self._instance.__del__()
 
@@ -230,7 +229,7 @@ class Application(QtWidgets.QMainWindow):
         args = QtCore.QCoreApplication.arguments()
 
         # Check if Connect is frozen (cx_freeze) and act accordingly.
-        if not hasattr(sys, 'frozen'):
+        if not hasattr(sys, "frozen"):
             path = sys.executable
         else:
             args.pop(0)
@@ -238,33 +237,33 @@ class Application(QtWidgets.QMainWindow):
         status = -1
 
         self.logger.debug(
-            f'Connect restarting with :: path: {path} argv: {args}'
+            f"Connect restarting with :: path: {path} argv: {args}"
         )
         try:
             status = process.startDetached(path, args)
         except Exception as error:
             self.logger.exception(str(error))
 
-        self.logger.debug(f'Connect restarted with status {status}')
+        self.logger.debug(f"Connect restarted with status {status}")
 
         return status
 
     def ftrack_title_icon(self, theme=None):
-        logo_path = ':ftrack/titlebar/logo'
+        logo_path = ":ftrack/titlebar/logo"
         return logo_path
 
     def ftrack_tray_icon(self, theme=None):
-        logo_path = ':ftrack/logo/{}'
+        logo_path = ":ftrack/logo/{}"
 
         theme = theme or self.system_theme()
-        if platform.system() == 'Darwin':
-            result_logo = logo_path.format('darwin/{}'.format(theme))
+        if platform.system() == "Darwin":
+            result_logo = logo_path.format("darwin/{}".format(theme))
         else:
             result_logo = self.ftrack_title_icon(theme)
 
         return result_logo
 
-    def system_theme(self, fallback='light'):
+    def system_theme(self, fallback="light"):
         # replicate content of https://github.com/albertosottile/darkdetect/blob/master/darkdetect/__init__.py
         # as does not work when frozen
         if sys.platform == "darwin":
@@ -286,27 +285,27 @@ class Application(QtWidgets.QMainWindow):
         current_theme = stylemodule.theme()
         if not current_theme:
             self.logger.warning(
-                'System theme could not be determined, using: light'
+                "System theme could not be determined, using: light"
             )
             current_theme = fallback
 
         return current_theme.lower()
 
     def emitConnectUsage(self):
-        '''Emit data to intercom to track Connect data usage'''
+        """Emit data to intercom to track Connect data usage"""
         connect_stopped_time = time.time()
 
         metadata = {
-            'label': 'ftrack-connect',
-            'version': ftrack_connect.__version__,
-            'os': platform.platform(),
-            'session-duration': connect_stopped_time
+            "label": "ftrack-connect",
+            "version": ftrack_connect.__version__,
+            "os": platform.platform(),
+            "session-duration": connect_stopped_time
             - self.__connect_start_time,
         }
 
         usage_tracker = get_usage_tracker()
         if usage_tracker:
-            usage_tracker.track('USED-CONNECT', metadata)
+            usage_tracker.track("USED-CONNECT", metadata)
 
     def _post_login_settings(self):
         if self.tray:
@@ -317,15 +316,15 @@ class Application(QtWidgets.QMainWindow):
             self.session.connect_theme = theme
 
     def theme(self):
-        '''Return current theme.'''
+        """Return current theme."""
         return self._theme
 
-    def _set_theme(self, theme='system'):
-        '''Set *theme*.'''
-        if theme not in ['light', 'dark']:
+    def _set_theme(self, theme="system"):
+        """Set *theme*."""
+        if theme not in ["light", "dark"]:
             theme = self.system_theme()
 
-        self.logger.debug('Setting theme {}'.format(theme))
+        self.logger.debug("Setting theme {}".format(theme))
         self._theme = theme
 
         self.setWindowIcon(
@@ -340,52 +339,52 @@ class Application(QtWidgets.QMainWindow):
         qtawesome_style(QtWidgets.QApplication.instance())
 
         ftrack_connect.ui.theme.applyFont()
-        ftrack_connect.ui.theme.applyTheme(self, self.theme(), 'cleanlooks')
+        ftrack_connect.ui.theme.applyTheme(self, self.theme(), "cleanlooks")
 
     def _onConnectTopicEvent(self, event):
-        '''Generic callback for all ftrack.connect events.
+        """Generic callback for all ftrack.connect events.
 
         .. note::
             Events not triggered by the current logged in user will be dropped.
 
-        '''
-        if event['topic'] != 'ftrack.connect':
+        """
+        if event["topic"] != "ftrack.connect":
             return
 
         self._route_event(event)
 
     def logout(self):
-        '''Clear stored credentials and quit Connect.'''
+        """Clear stored credentials and quit Connect."""
         self._clear_qsettings()
         config = load_credentials()
 
-        config['accounts'] = []
+        config["accounts"] = []
         store_credentials(config)
 
         QtWidgets.QApplication.quit()
 
     def _clear_qsettings(self):
-        '''Remove credentials from QSettings.'''
+        """Remove credentials from QSettings."""
         settings = QtCore.QSettings()
-        settings.remove('login')
+        settings.remove("login")
 
     def _get_credentials(self):
-        '''Return a dict with API credentials from storage.'''
+        """Return a dict with API credentials from storage."""
         credentials = None
 
         # Read from json config file.
         json_config = load_credentials()
         if json_config:
             try:
-                data = json_config['accounts'][0]
+                data = json_config["accounts"][0]
                 credentials = {
-                    'server_url': data['server_url'],
-                    'api_user': data['api_user'],
-                    'api_key': data['api_key'],
+                    "server_url": data["server_url"],
+                    "api_user": data["api_user"],
+                    "api_key": data["api_key"],
                 }
             except Exception:
                 self.logger.debug(
-                    u'No credentials were found in config: {0}.'.format(
+                    "No credentials were found in config: {0}.".format(
                         json_config
                     )
                 )
@@ -393,21 +392,21 @@ class Application(QtWidgets.QMainWindow):
         # Fallback on old QSettings.
         if not json_config and not credentials:
             settings = QtCore.QSettings()
-            server_url = settings.value('login/server', None)
-            api_user = settings.value('login/username', None)
-            api_key = settings.value('login/apikey', None)
+            server_url = settings.value("login/server", None)
+            api_user = settings.value("login/username", None)
+            api_key = settings.value("login/apikey", None)
 
-            if not None in (server_url, api_user, api_key):
+            if None not in (server_url, api_user, api_key):
                 credentials = {
-                    'server_url': server_url,
-                    'api_user': api_user,
-                    'api_key': api_key,
+                    "server_url": server_url,
+                    "api_user": api_user,
+                    "api_key": api_key,
                 }
 
         return credentials
 
     def _save_credentials(self, server_url, api_user, api_key):
-        '''Save API credentials to storage.'''
+        """Save API credentials to storage."""
         # Clear QSettings since they should not be used any more.
         self._clear_qsettings()
 
@@ -419,36 +418,36 @@ class Application(QtWidgets.QMainWindow):
 
         # Add a unique id to the config that can be used to identify this
         # machine.
-        if not 'id' in json_config:
-            json_config['id'] = str(uuid.uuid4())
+        if "id" not in json_config:
+            json_config["id"] = str(uuid.uuid4())
 
-        json_config['accounts'] = [
+        json_config["accounts"] = [
             {
-                'server_url': server_url,
-                'api_user': api_user,
-                'api_key': api_key,
+                "server_url": server_url,
+                "api_user": api_user,
+                "api_key": api_key,
             }
         ]
 
         store_credentials(json_config)
 
     def login(self):
-        '''Login using stored credentials or ask user for them.'''
+        """Login using stored credentials or ask user for them."""
         credentials = self._get_credentials()
         self._show_login_widget()
 
         if credentials:
             # Try to login.
             self.loginWithCredentials(
-                credentials['server_url'],
-                credentials['api_user'],
-                credentials['api_key'],
+                credentials["server_url"],
+                credentials["api_user"],
+                credentials["api_key"],
             )
 
     def _show_login_widget(self):
-        '''Show the login widget.'''
+        """Show the login widget."""
         self._login_overlay = ftrack_connect.ui.widget.overlay.CancelOverlay(
-            self._login_widget, message='<h2>Signing in<h2/>'
+            self._login_widget, message="<h2>Signing in<h2/>"
         )
 
         self._login_overlay.hide()
@@ -468,7 +467,7 @@ class Application(QtWidgets.QMainWindow):
         api_plugin_paths = []
 
         for apiPluginPath in os.environ.get(
-            'FTRACK_EVENT_PLUGIN_PATH', ''
+            "FTRACK_EVENT_PLUGIN_PATH", ""
         ).split(os.pathsep):
             if apiPluginPath and apiPluginPath not in api_plugin_paths:
                 api_plugin_paths.append(os.path.expandvars(apiPluginPath))
@@ -476,21 +475,21 @@ class Application(QtWidgets.QMainWindow):
         checked_plugins = []
         for plugin in self.plugins:
             # Always pick the
-            if plugin['name'] in checked_plugins:
+            if plugin["name"] in checked_plugins:
                 continue
-            if plugin['incompatible']:
+            if plugin["incompatible"]:
                 self.logger.warning(
                     f'Ignoring plugin that is incompatible: {plugin["path"]}'
                 )
                 continue
-            checked_plugins.append(plugin['name'])
-            api_plugin_paths.append(os.path.join(plugin['path'], 'hook'))
+            checked_plugins.append(plugin["name"])
+            api_plugin_paths.append(os.path.join(plugin["path"], "hook"))
 
         return api_plugin_paths
 
     def _setup_session(self, api_plugin_paths=None):
-        '''Setup a new python API session.'''
-        if hasattr(self, '_hub_thread'):
+        """Setup a new python API session."""
+        if hasattr(self, "_hub_thread"):
             self._hub_thread.cleanup()
 
         if api_plugin_paths is None:
@@ -504,7 +503,7 @@ class Application(QtWidgets.QMainWindow):
 
         # Need to reconfigure logging after session is created.
         ftrack_connect.utils.log.configure_logging(
-            'ftrack_connect', level=self._log_level, notify=False
+            "ftrack_connect", level=self._log_level, notify=False
         )
 
         # Listen to events using the new API event hub. This is required to
@@ -534,51 +533,51 @@ class Application(QtWidgets.QMainWindow):
         return session
 
     def _report_session_setup_error(self, error):
-        '''Format error message and emit loginError.'''
+        """Format error message and emit loginError."""
         msg = (
-            u'\nAn error occured while starting ftrack-connect: <b>{0}</b>.'
-            u'\nPlease check log file for more informations.'
-            u'\nIf the error persists please send the log file to:'
-            u' support@ftrack.com'.format(error)
+            "\nAn error occured while starting ftrack-connect: <b>{0}</b>."
+            "\nPlease check log file for more informations."
+            "\nIf the error persists please send the log file to:"
+            " support@ftrack.com".format(error)
         )
         self.loginError.emit(msg)
 
     def loginWithCredentials(self, url, username, apiKey):
-        '''Connect to *url* with *username* and *apiKey*.
+        """Connect to *url* with *username* and *apiKey*.
 
         loginError will be emitted if this fails.
 
-        '''
+        """
         # Strip all leading and preceeding occurances of slash and space.
-        url = url.strip('/ ')
+        url = url.strip("/ ")
 
         if not url:
             self.loginError.emit(
-                'You need to specify a valid server URL, '
-                'for example https://server-name.ftrackapp.com'
+                "You need to specify a valid server URL, "
+                "for example https://server-name.ftrackapp.com"
             )
             return
 
-        if not 'http' in url:
-            if url.endswith('ftrackapp.com'):
-                url = 'https://' + url
+        if "http" not in url:
+            if url.endswith("ftrackapp.com"):
+                url = "https://" + url
             else:
-                url = 'https://{0}.ftrackapp.com'.format(url)
+                url = "https://{0}.ftrackapp.com".format(url)
 
         try:
             result = requests.get(
                 url,
             )
         except requests.exceptions.RequestException:
-            self.logger.exception('Error reaching server url.')
+            self.logger.exception("Error reaching server url.")
             self.loginError.emit(
-                'The server URL you provided could not be reached.'
+                "The server URL you provided could not be reached."
             )
             return
 
-        if result.status_code != 200 or 'FTRACK_VERSION' not in result.headers:
+        if result.status_code != 200 or "FTRACK_VERSION" not in result.headers:
             self.loginError.emit(
-                'The server URL you provided is not a valid ftrack server.'
+                "The server URL you provided is not a valid ftrack server."
             )
             return
 
@@ -599,17 +598,17 @@ class Application(QtWidgets.QMainWindow):
             return
 
         # Set environment variables supported by the new API.
-        os.environ['FTRACK_SERVER'] = url
-        os.environ['FTRACK_API_USER'] = username
-        os.environ['FTRACK_API_KEY'] = apiKey
+        os.environ["FTRACK_SERVER"] = url
+        os.environ["FTRACK_API_USER"] = username
+        os.environ["FTRACK_API_KEY"] = apiKey
 
         # Login using the new ftrack API.
         try:
             # Quick session to poll for settings, confirm credentials
-            self._session = self._setup_session(api_plugin_paths='')
+            self._session = self._setup_session(api_plugin_paths="")
             self._assign_session_theme(self.theme())
         except Exception as error:
-            self.logger.exception('Error during login:')
+            self.logger.exception("Error during login:")
             self._report_session_setup_error(error)
             return
 
@@ -617,16 +616,16 @@ class Application(QtWidgets.QMainWindow):
         self._save_credentials(url, username, apiKey)
 
         # Verify storage scenario before starting.
-        if 'storage_scenario' in self.session.server_information:
+        if "storage_scenario" in self.session.server_information:
             storage_scenario = self.session.server_information.get(
-                'storage_scenario'
+                "storage_scenario"
             )
             if storage_scenario is None:
                 ftrack_api.plugin.discover(
                     self._get_api_plugin_paths(), [self.session]
                 )
                 # Hide login overlay at this time since it will be deleted
-                self.logger.debug('Storage scenario is not configured.')
+                self.logger.debug("Storage scenario is not configured.")
                 scenario_widget = _scenario_widget.ConfigureScenario(
                     self.session
                 )
@@ -643,21 +642,31 @@ class Application(QtWidgets.QMainWindow):
         self.loginSuccessSignal.emit()
 
     def _location_configuration_finished(self, reconfigure_session=True):
-        '''Continue connect setup after location configuration is done.'''
+        """Continue connect setup after location configuration is done."""
         if reconfigure_session:
             try:
                 self.session.event_hub.disconnect(False)
             except ftrack_api.exception.EventHubConnectionError:
                 # Maybe it wasn't connected yet.
-                self.logger.exception('Failed to disconnect from event hub.')
+                self.logger.exception("Failed to disconnect from event hub.")
                 pass
+
+        # NEW: Properly close the existing session before creating a new one
+        if self._session is not None:
+            try:
+                self.logger.debug(
+                    "Closing existing session before reconfiguration."
+                )
+                self._session.close()
+            except Exception as error:
+                self.logger.warning(f"Error closing existing session: {error}")
 
         self._session = self._setup_session()
 
         try:
             self._configure_connect_and_discover_plugins()
         except Exception as error:
-            self.logger.exception(u'Error during location configuration:')
+            self.logger.exception("Error during location configuration:")
             self._report_session_setup_error(error)
         else:
             self.focus()
@@ -665,10 +674,10 @@ class Application(QtWidgets.QMainWindow):
         # Send verify startup event to verify that storage scenario is
         # working correctly.
         event = ftrack_api.event.base.Event(
-            topic='ftrack.connect.verify-startup',
+            topic="ftrack.connect.verify-startup",
             data={
-                'storage_scenario': self.session.server_information.get(
-                    'storage_scenario'
+                "storage_scenario": self.session.server_information.get(
+                    "storage_scenario"
                 )
             },
         )
@@ -677,14 +686,14 @@ class Application(QtWidgets.QMainWindow):
         if problems:
             msgBox = QtWidgets.QMessageBox(parent=self)
             msgBox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-            msgBox.setText('\n\n'.join(problems))
+            msgBox.setText("\n\n".join(problems))
             msgBox.exec_()
 
     def _configure_connect_and_discover_plugins(self):
-        '''Configure connect and load plugins.'''
+        """Configure connect and load plugins."""
 
         self.tabPanel = _tab_widget.TabWidget()
-        self.tabPanel.tabBar().setObjectName('application-tab-bar')
+        self.tabPanel.tabBar().setObjectName("application-tab-bar")
         self.setCentralWidget(self.tabPanel)
 
         self.session.event_hub.subscribe(
@@ -716,27 +725,27 @@ class Application(QtWidgets.QMainWindow):
         self._discover_connect_widgets()
 
     def _gather_plugins(self, plugin_directory, source_index=None):
-        '''Return plugin data from *plugin_directory*.'''
+        """Return plugin data from *plugin_directory*."""
 
         result = []
         if not plugin_directory:
             return result
         self.logger.debug(
-            u'Searching {0!r} for plugin hooks.'.format(plugin_directory)
+            "Searching {0!r} for plugin hooks.".format(plugin_directory)
         )
         if os.path.isdir(plugin_directory):
             for candidate in get_plugins_from_path(plugin_directory):
-                self.logger.debug(f'Checking candidate {candidate}.')
+                self.logger.debug(f"Checking candidate {candidate}.")
                 candidate_path = os.path.join(plugin_directory, candidate)
                 plugin_data = get_plugin_data(candidate_path)
                 if not plugin_data:
                     continue
                 if source_index >= 0:
-                    plugin_data['source_index'] = source_index
+                    plugin_data["source_index"] = source_index
                 result.append(plugin_data)
 
         self.logger.debug(
-            u'Found {0!r} plugin hooks in {1!r}.'.format(
+            "Found {0!r} plugin hooks in {1!r}.".format(
                 result, plugin_directory
             )
         )
@@ -744,7 +753,7 @@ class Application(QtWidgets.QMainWindow):
         return result
 
     def _available_plugin_data_from_plugin_directories(self):
-        '''Return a list of plugin data'''
+        """Return a list of plugin data"""
 
         result = []
         i = 0
@@ -757,37 +766,37 @@ class Application(QtWidgets.QMainWindow):
                 found = False
                 for existing_plugin in result:
                     if (
-                        existing_plugin['name'].lower()
-                        == plugin['name'].lower()
+                        existing_plugin["name"].lower()
+                        == plugin["name"].lower()
                     ):
                         found = True
                         break
                 # Make sure we pick the compatible latest version of the plugin from the current folder
                 for current_dir_plugin in current_dir_plugins:
                     if (
-                        current_dir_plugin['name'].lower()
-                        == plugin['name'].lower()
+                        current_dir_plugin["name"].lower()
+                        == plugin["name"].lower()
                     ):
                         if (
-                            current_dir_plugin['incompatible']
-                            and not plugin['incompatible']
+                            current_dir_plugin["incompatible"]
+                            and not plugin["incompatible"]
                         ):
                             current_dir_plugins.remove(current_dir_plugin)
                             break
                         elif (
-                            current_dir_plugin['deprecated']
-                            and not plugin['incompatible']
-                            and not plugin['deprecated']
+                            current_dir_plugin["deprecated"]
+                            and not plugin["incompatible"]
+                            and not plugin["deprecated"]
                         ):
                             current_dir_plugins.remove(current_dir_plugin)
                             break
                         elif (
-                            not plugin['incompatible']
-                            and not plugin['deprecated']
+                            not plugin["incompatible"]
+                            and not plugin["deprecated"]
                         ):
                             if (
-                                current_dir_plugin['version']
-                                < plugin['version']
+                                current_dir_plugin["version"]
+                                < plugin["version"]
                             ):
                                 current_dir_plugins.remove(current_dir_plugin)
                                 break
@@ -800,7 +809,7 @@ class Application(QtWidgets.QMainWindow):
         return result
 
     def _discover_plugin_data_from_plugin_directories(self):
-        '''Return a list of all plugin data from the plugin directories'''
+        """Return a list of all plugin data from the plugin directories"""
 
         result = []
         i = 0
@@ -812,11 +821,11 @@ class Application(QtWidgets.QMainWindow):
         return result
 
     def _relay_event(self, event):
-        '''Relay all ftrack.connect events.'''
+        """Relay all ftrack.connect events."""
         self.eventHubSignal.emit(event)
 
     def _initialise_tray(self):
-        '''Initialise and add application icon to system tray.'''
+        """Initialise and add application icon to system tray."""
         self.trayMenu = self._create_tray_menu()
 
         self.tray = QtWidgets.QSystemTrayIcon(self)
@@ -824,36 +833,36 @@ class Application(QtWidgets.QMainWindow):
         self.tray.setContextMenu(self.trayMenu)
 
     def _initialise_menu_bar(self):
-        '''Initialise and add connect widget to widgets menu.'''
+        """Initialise and add connect widget to widgets menu."""
 
         self.menu_bar = QtWidgets.QMenuBar(self.centralWidget())
         self.setMenuWidget(self.menu_bar)
-        widget_menu = self.menu_bar.addMenu('Widgets')
+        widget_menu = self.menu_bar.addMenu("Widgets")
         self.menu_widget = widget_menu
         self.menu_bar.setVisible(False)
 
     def _create_tray_menu(self):
-        '''Return a menu for system tray.'''
+        """Return a menu for system tray."""
         menu = QtWidgets.QMenu(self.centralWidget())
 
-        logoutAction = QAction('Log Out && Quit', self, triggered=self.logout)
+        logoutAction = QAction("Log Out && Quit", self, triggered=self.logout)
 
         quitAction = QAction(
-            'Quit', self, triggered=QtWidgets.QApplication.quit
+            "Quit", self, triggered=QtWidgets.QApplication.quit
         )
 
-        focusAction = QAction('Open', self, triggered=self.focus)
+        focusAction = QAction("Open", self, triggered=self.focus)
 
         openPluginDirectoryAction = QAction(
-            'Open plugin directory',
+            "Open plugin directory",
             self,
             triggered=self._open_default_plugin_directory,
         )
 
-        aboutAction = QAction('About', self, triggered=self._show_about)
+        aboutAction = QAction("About", self, triggered=self._show_about)
 
-        alwaysOnTopAction = QAction('Always on top', self)
-        restartAction = QAction('Restart', self, triggered=self.restart)
+        alwaysOnTopAction = QAction("Always on top", self)
+        restartAction = QAction("Restart", self, triggered=self.restart)
         alwaysOnTopAction.setCheckable(True)
         alwaysOnTopAction.triggered[bool].connect(self._set_always_on_top)
 
@@ -874,7 +883,7 @@ class Application(QtWidgets.QMainWindow):
         return menu
 
     def _discover_connect_widgets(self):
-        '''Find and load connect widgets in search paths.'''
+        """Find and load connect widgets in search paths."""
 
         event = ftrack_api.event.base.Event(topic=ConnectWidgetPlugin.topic)
         responses = self.session.event_hub.publish(event, synchronous=True)
@@ -889,13 +898,13 @@ class Application(QtWidgets.QMainWindow):
 
             except Exception:
                 self.logger.exception(
-                    msg='Error while loading plugin : {}'.format(widget_plugin)
+                    msg="Error while loading plugin : {}".format(widget_plugin)
                 )
                 continue
 
             if not isinstance(widget_plugin, ConnectWidget):
                 self.logger.warning(
-                    'Widget {} is not a valid ConnectWidget'.format(
+                    "Widget {} is not a valid ConnectWidget".format(
                         widget_plugin
                     )
                 )
@@ -906,7 +915,7 @@ class Application(QtWidgets.QMainWindow):
                     self._widget_plugin_instances[identifier] = widget_plugin
                 else:
                     self.logger.debug(
-                        'Widget {} already registered'.format(identifier)
+                        "Widget {} already registered".format(identifier)
                     )
                     continue
 
@@ -920,7 +929,7 @@ class Application(QtWidgets.QMainWindow):
                 )
 
     def _route_event(self, event):
-        '''Route websocket *event* to publisher plugin.
+        """Route websocket *event* to publisher plugin.
 
         Expect event['data'] to contain:
 
@@ -930,9 +939,9 @@ class Application(QtWidgets.QMainWindow):
         Raise `ConnectError` if no plugin is found or if action is missing on
         plugin.
 
-        '''
-        plugin = event['data']['plugin']
-        action = event['data']['action']
+        """
+        plugin = event["data"]["plugin"]
+        action = event["data"]["action"]
 
         try:
             pluginInstance = self._widget_plugin_instances[plugin]
@@ -953,20 +962,20 @@ class Application(QtWidgets.QMainWindow):
         method(event)
 
     def _on_fetch_plugins_callback(self, callback_fn):
-        '''Call *callback_fn* with list of active Connect plugins'''
+        """Call *callback_fn* with list of active Connect plugins"""
         callback_fn(self.plugins)
 
     def _on_widget_request_application_focus_callback(self, widget):
-        '''Switch tab to *widget* and bring application to front.'''
+        """Switch tab to *widget* and bring application to front."""
         self.tabPanel.setCurrentWidget(widget)
         self.focus()
 
     def _on_widget_request_acpplication_close_callback(self, widget):
-        '''Hide application upon *widget* request.'''
+        """Hide application upon *widget* request."""
         self.hide()
 
     def _add_plugin(self, plugin, name=None):
-        '''Add *plugin* in new tab with *name* and *identifier*.
+        """Add *plugin* in new tab with *name* and *identifier*.
 
         *plugin* should be an instance of :py:class:`ApplicationPlugin`.
 
@@ -976,7 +985,7 @@ class Application(QtWidgets.QMainWindow):
         *identifier* will be used for routing events to plugins. If
         *identifier* is None then plugin.getIdentifier() will be used.
 
-        '''
+        """
         if name is None:
             name = plugin.getName()
 
@@ -999,14 +1008,14 @@ class Application(QtWidgets.QMainWindow):
 
         plugin.refresh()
 
-        self.logger.debug(f'Plugin {name}({plugin.__class__.__name__}) added')
+        self.logger.debug(f"Plugin {name}({plugin.__class__.__name__}) added")
 
     def _remove_plugin(self, plugin):
-        '''Remove plugin registered with *identifier*.
+        """Remove plugin registered with *identifier*.
 
         Raise :py:exc:`KeyError` if no plugin with *identifier* has been added.
 
-        '''
+        """
         identifier = plugin.getIdentifier()
         registered_plugin = self._widget_plugin_instances.get(identifier)
 
@@ -1022,13 +1031,13 @@ class Application(QtWidgets.QMainWindow):
         self.tabPanel.removeTab(index)
 
     def focus(self):
-        '''Focus and bring the window to top.'''
+        """Focus and bring the window to top."""
         self.activateWindow()
         self.show()
         self.raise_()
 
     def _set_always_on_top(self, state):
-        '''Set the application window to be on top'''
+        """Set the application window to be on top"""
         if state:
             self.setWindowFlags(
                 self.windowFlags() | QtCore.Qt.WindowType.WindowStaysOnTopHint
@@ -1040,9 +1049,7 @@ class Application(QtWidgets.QMainWindow):
         self.focus()
 
     def _show_about(self):
-        '''Display window with about information.'''
-        from ftrack_connect.plugin_manager import PluginManager
-        from ftrack_connect.plugin_manager.processor import ROLES, STATUSES
+        """Display window with about information."""
 
         self.focus()
 
@@ -1051,31 +1058,31 @@ class Application(QtWidgets.QMainWindow):
         environment_data = os.environ.copy()
         environment_data.update(
             {
-                'PLATFORM': platform.platform(),
-                'PYTHON_VERSION': platform.python_version(),
+                "PLATFORM": platform.platform(),
+                "PYTHON_VERSION": platform.python_version(),
             }
         )
 
-        debug_information = {'environment': environment_data, 'widgets': []}
+        debug_information = {"environment": environment_data, "widgets": []}
 
         # Provide debug information from application launcher
         if self._application_launcher:
-            debug_information[
-                'application_launcher'
-            ] = self._application_launcher.get_debug_information()
+            debug_information["application_launcher"] = (
+                self._application_launcher.get_debug_information()
+            )
 
         # Provide information from builtin widget plugins.
         for plugin in self._widget_plugin_instances:
             if isinstance(plugin, ConnectWidget):
-                debug_information['widgets'].append(
+                debug_information["widgets"].append(
                     plugin.get_debug_information()
                 )
 
         connect_version_data = {
-            'name': 'ftrack connect',
-            'version': ftrack_connect.__version__,
-            'core': True,
-            'debug_information': debug_information,
+            "name": "ftrack connect",
+            "version": ftrack_connect.__version__,
+            "core": True,
+            "debug_information": debug_information,
         }
 
         result = [connect_version_data]
@@ -1089,7 +1096,7 @@ class Application(QtWidgets.QMainWindow):
 
         try:
             event = ftrack_api.event.base.Event(
-                topic='ftrack.connect.plugin.debug-information'
+                topic="ftrack.connect.plugin.debug-information"
             )
 
             raw_responses = self.session.event_hub.publish(
@@ -1103,12 +1110,12 @@ class Application(QtWidgets.QMainWindow):
                 elif isinstance(response, list):
                     responses.extend(response)
             for response in responses:
-                if response.get('core'):
+                if response.get("core"):
                     result.append(response)
                     continue
                 found = False
                 for plugin_data in result:
-                    if plugin_data['name'] == response['name']:
+                    if plugin_data["name"] == response["name"]:
                         found = True
                         # Update information
                         plugin_data.update(response)
@@ -1118,25 +1125,25 @@ class Application(QtWidgets.QMainWindow):
         except Exception as error:
             self.logger.error(error)
 
-        current_plugins_path = [plugin['path'] for plugin in self.plugins]
+        current_plugins_path = [plugin["path"] for plugin in self.plugins]
         # Highlight compatibility and source of plugins
         for plugin_data in result:
-            if plugin_data.get('core') or 'path' not in plugin_data:
+            if plugin_data.get("core") or "path" not in plugin_data:
                 continue
             tags = []
-            if plugin_data.get('incompatible'):
-                tags.append('Incompatible')
-            elif plugin_data.get('deprecated'):
-                tags.append('Deprecated')
-            if plugin_data['path'] not in current_plugins_path:
-                tags.append('Ignored')
-            plugin_data['tags'] = ",".join(tags)
+            if plugin_data.get("incompatible"):
+                tags.append("Incompatible")
+            elif plugin_data.get("deprecated"):
+                tags.append("Deprecated")
+            if plugin_data["path"] not in current_plugins_path:
+                tags.append("Ignored")
+            plugin_data["tags"] = ",".join(tags)
 
-        sorted_version_data = sorted(result, key=itemgetter('name'))
+        sorted_version_data = sorted(result, key=itemgetter("name"))
 
         aboutDialog.setInformation(
             versionData=sorted_version_data,
-            server=os.environ.get('FTRACK_SERVER', 'Not set'),
+            server=os.environ.get("FTRACK_SERVER", "Not set"),
             user=self.session.api_user,
             widget_plugins=self._widget_plugin_instances,
         )
@@ -1144,7 +1151,7 @@ class Application(QtWidgets.QMainWindow):
         aboutDialog.exec_()
 
     def _open_default_plugin_directory(self):
-        '''Open default plugin directory in platform default file browser.'''
+        """Open default plugin directory in platform default file browser."""
 
         try:
             create_target_plugin_directory(PLUGIN_DIRECTORIES[0])
@@ -1152,8 +1159,8 @@ class Application(QtWidgets.QMainWindow):
             messageBox = QtWidgets.QMessageBox(parent=self)
             messageBox.setIcon(QtWidgets.QMessageBox.Icon.Warning)
             messageBox.setText(
-                u'Could not open or create default plugin '
-                u'directory: {0}.'.format(get_default_plugin_directory())
+                "Could not open or create default plugin "
+                "directory: {0}.".format(get_default_plugin_directory())
             )
             messageBox.exec_()
             return
@@ -1161,17 +1168,17 @@ class Application(QtWidgets.QMainWindow):
         open_directory(get_default_plugin_directory())
 
     def _discover_applications(self):
-        '''Walk through Connect plugins and pick up application launcher
-        configuration files.'''
+        """Walk through Connect plugins and pick up application launcher
+        configuration files."""
         launcher_config_paths = []
 
         self.logger.debug(
-            f'Discovering applications launcher configs based on'
-            f' {len(self.plugins)} plugins.'
+            f"Discovering applications launcher configs based on"
+            f" {len(self.plugins)} plugins."
         )
 
-        for connect_plugin_path in [plugin['path'] for plugin in self.plugins]:
-            launcher_config_path = os.path.join(connect_plugin_path, 'launch')
+        for connect_plugin_path in [plugin["path"] for plugin in self.plugins]:
+            launcher_config_path = os.path.join(connect_plugin_path, "launch")
             if os.path.isdir(launcher_config_path):
                 launcher_config_paths.append(launcher_config_path)
 
@@ -1182,8 +1189,8 @@ class Application(QtWidgets.QMainWindow):
         self._application_launcher.register()
 
     def _configure_action_launcher_widget(self):
-        '''Append action launcher widget to list of build in
-        plugins to add on discovery together with user plugins.'''
+        """Append action launcher widget to list of build in
+        plugins to add on discovery together with user plugins."""
 
         from ftrack_connect.action_launcher import ActionLauncherWidget
 
@@ -1191,25 +1198,25 @@ class Application(QtWidgets.QMainWindow):
         self._builtin_widget_plugins.append(ActionLauncherWidget)
 
     def _configure_plugin_manager_widget(self):
-        '''Append plugin manager widget to list of build in
-        plugins to add on discovery together with user plugins.'''
+        """Append plugin manager widget to list of build in
+        plugins to add on discovery together with user plugins."""
 
         from ftrack_connect.plugin_manager import PluginManager
 
         if (
-            os.environ.get('FTRACK_CONNECT_DISABLE_PLUGIN_MANAGER') or ''
+            os.environ.get("FTRACK_CONNECT_DISABLE_PLUGIN_MANAGER") or ""
         ).lower() not in [
-            'true',
-            '1',
+            "true",
+            "1",
         ]:
             # Add together with discovered widgets
             self._builtin_widget_plugins.append(PluginManager)
         else:
             self.logger.warning(
-                'Plugin manager disabled by user environment variable.'
+                "Plugin manager disabled by user environment variable."
             )
 
     def closeEvent(self, event):
-        ''' ' Quit application when main window is closed, and no tray'''
+        """' Quit application when main window is closed, and no tray"""
         if not self.tray:
             sys.exit(0)


### PR DESCRIPTION
## What

Fixes double session initialization in Connect: `_location_configuration_finished` created a fresh API session while the previous one (and its event hub connection) was left open. The existing session is now explicitly closed before a new one is created.

The file is also reformatted to the repo's ruff style (single → double quotes), which accounts for most of the diff.

## Review follow-ups

Addressed all CodeRabbit findings in 20cf656:

- **`restart()` crash with `--allow-multiple`**: `__main__.py` passes `instance=None` when the lockfile is skipped, and `restart()` dereferenced it unconditionally (AttributeError before relaunch). Now guarded.
- **Plugin version comparison**: picking the latest duplicate plugin compared raw strings (`"10.0.0" < "2.0.0"`). Now parsed with `packaging.version`, falling back to lexical comparison for non-PEP 440 folder versions so discovery can't break. Note this also corrects pre-release ordering: `24.0.0rc1` now ranks *older* than `24.0.0`.
- **About-dialog debug info**: the loop iterated `_widget_plugin_instances` dict keys, so the `isinstance(..., ConnectWidget)` check never matched and widget debug info was silently dropped. Now iterates values.
- Malformed `<h2/>` tag in the "Signing in" login overlay.
- Removed temporal `# NEW:` comment marker.

## Verification

- Built per `apps/connect/README.md` (venv, `build_qt_resources`, `uv lock`/`uv sync`, `uv build`) — wheel builds clean; regenerated `resource.py` is byte-identical apart from embedded mtimes.
- Ran Connect from source (`uv run python -m ftrack_connect --verbosity debug`): auto-login, storage scenario activated, 6 plugins discovered with compatibility checks, publisher widget populated from the live server, stable event hub, clean shutdown. The only logged error is a pre-existing shutdown race (USED-CONNECT usage event sent after session close), untouched by this PR.
- `ruff format`/`ruff check` pass with the pre-commit-pinned ruff 0.4.4; version-comparison logic covered by assertion tests against `packaging` 25.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error messages for startup and login failures
  * More reliable session handling to reduce connection issues

* **Improvements**
  * About dialog shows plugin details with compatibility tags
  * More robust plugin discovery/loading with improved error handling
  * Updated theme application and UI modernization for cleaner visuals
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
