### PR TITLE
fix: plugins fetched in main thread

### DIFF
--- a/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/__init__.py
@@ -11,9 +11,8 @@ except ImportError:
     from PySide2 import QtWidgets, QtCore, QtGui
 
 from ftrack_connect.utils.thread import qt_main_thread
-from ftrack_connect.utils.plugin import PLUGIN_DIRECTORIES
 
-from ftrack_connect.ui.widget.overlay import BlockingOverlay, BusyOverlay
+from ftrack_connect.ui.widget.overlay import BusyOverlay
 import ftrack_connect.ui.application
 
 from ftrack_utils.decorators import asynchronous
@@ -26,9 +25,9 @@ from ftrack_connect.plugin_manager.welcome import WelcomeDialog
 
 
 class PluginManager(ftrack_connect.ui.application.ConnectWidget):
-    '''Show and manage plugin installations.'''
+    """Show and manage plugin installations."""
 
-    name = 'Plugins'
+    name = "Plugins"
 
     show_welcome = QtCore.Signal(
         object
@@ -47,7 +46,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     @property
     def items(self):
-        '''Return items in plugin list.'''
+        """Return items in plugin list."""
         result = []
         num_items = self._plugin_list_widget.plugin_model.rowCount()
         for i in range(num_items):
@@ -57,12 +56,12 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     @property
     def installed_plugins(self):
-        '''Return list of installed plugins'''
+        """Return list of installed plugins"""
         return self._installed_plugins
 
     # default methods
     def __init__(self, session, parent=None):
-        '''Instantiate the plugin widget.'''
+        """Instantiate the plugin widget."""
         super(PluginManager, self).__init__(session, parent=parent)
         self._label = None
         self._select_release_type_widget = None
@@ -78,6 +77,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._counter = 0
         self._initialised = False
         self._installed_plugins = None
+        self._show_welcome_pending = False
 
         self._reset_plugin_list()
         self._plugin_processor = PluginProcessor()
@@ -92,12 +92,12 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     def build(self):
         self._search_bar = QtWidgets.QLineEdit()
-        self._search_bar.setPlaceholderText('Search plugin...')
+        self._search_bar.setPlaceholderText("Search plugin...")
 
         self.layout().addWidget(self._search_bar)
         self._label = QtWidgets.QLabel(
-            'Check the plugins you want to install or add your'
-            ' local plugins by dropping them on the list below'
+            "Check the plugins you want to install or add your"
+            " local plugins by dropping them on the list below"
         )
         self._label.setWordWrap(True)
         self._label.setMargin(5)
@@ -105,7 +105,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
         # choose release type
         self._select_release_type_widget = QtWidgets.QCheckBox(
-            'Show pre-releases'
+            "Show pre-releases"
         )
         self.layout().addWidget(self._select_release_type_widget)
         # plugin list
@@ -115,12 +115,12 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         # apply and reset button.
         self._button_layout = QtWidgets.QHBoxLayout()
 
-        self._apply_button = QtWidgets.QPushButton('Install Plugins')
-        self._apply_button.setIcon(QtGui.QIcon(qta.icon('mdi6.check')))
+        self._apply_button = QtWidgets.QPushButton("Install Plugins")
+        self._apply_button.setIcon(QtGui.QIcon(qta.icon("mdi6.check")))
         self._apply_button.setDisabled(True)
 
-        self._reset_button = QtWidgets.QPushButton('Clear selection')
-        self._reset_button.setIcon(QtGui.QIcon(qta.icon('mdi6.lock-reset')))
+        self._reset_button = QtWidgets.QPushButton("Clear selection")
+        self._reset_button.setIcon(QtGui.QIcon(qta.icon("mdi6.lock-reset")))
         self._reset_button.setMaximumWidth(120)
 
         self._button_layout.addWidget(self._apply_button)
@@ -138,7 +138,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._blocking_overlay = InstallerBlockingOverlay(self)
         self._blocking_overlay.hide()
 
-        self._busy_overlay = BusyOverlay(self, 'Updating....')
+        self._busy_overlay = BusyOverlay(self, "Updating....")
         self._busy_overlay.hide()
 
     def post_build(self):
@@ -168,6 +168,9 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._plugin_list_widget.plugin_model.itemChanged.connect(
             self._enable_apply_button
         )
+        self._plugin_list_widget.download_plugins_populated.connect(
+            self._on_download_plugins_populated
+        )
 
         self._blocking_overlay.confirm_button.clicked.connect(self.refresh)
         self._blocking_overlay.restart_button.clicked.connect(
@@ -182,15 +185,15 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._plugins_to_install = []
 
     def _emit_downloaded_plugins(self, plugins):
-        metadata = {'installed_plugins': []}
+        metadata = {"installed_plugins": []}
 
         for plugin in plugins:
             name = str(plugin.data(ROLES.PLUGIN_NAME))
             version = str(plugin.data(ROLES.PLUGIN_VERSION))
             _os = str(platform.platform())
 
-            plugin_data = {'name': name, 'version': version, 'os': _os}
-            metadata['installed_plugins'].append(plugin_data)
+            plugin_data = {"name": name, "version": version, "os": _os}
+            metadata["installed_plugins"].append(plugin_data)
 
         usage_tracker = get_usage_tracker()
         if usage_tracker:
@@ -198,7 +201,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     @qt_main_thread
     def _enable_apply_button(self, item):
-        '''Check the plugins state.'''
+        """Check the plugins state."""
         self._apply_button.setDisabled(True)
         items = []
         for index in range(self._plugin_list_widget.plugin_model.rowCount()):
@@ -214,14 +217,14 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
             self._apply_button.setEnabled(True)
 
         self._apply_button.setText(
-            f'Install {len(self._plugins_to_install)} Plugins'
+            f"Install {len(self._plugins_to_install)} Plugins"
         )
 
     @asynchronous
     def refresh(self):
-        '''Force refresh of the model, fetching all the available plugins. This
+        """Force refresh of the model, fetching all the available plugins. This
         function is run in a separate thread, make sure that UI alterations are
-        performed in QT main thread.'''
+        performed in QT main thread."""
         self.refresh_started.emit()
         self.fetchPlugins.emit(self._on_plugin_fetch_callback)
         self._enable_apply_button(None)
@@ -230,23 +233,31 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._initialised = True
 
     def _on_plugin_fetch_callback(self, plugins):
-        '''Callback on fetching installed plugins from Connect'''
+        """Callback on fetching installed plugins from Connect"""
         self._installed_plugins = plugins
         self._plugin_list_widget.populate_installed_plugins(plugins)
+        disable_startup_widget = bool(
+            os.getenv("FTRACK_CONNECT_DISABLE_STARTUP_WIDGET", False)
+        )
+        # Decide now if the welcome dialog should be shown; the downloadable
+        # plugin count is not known until download_plugins_populated arrives.
+        self._show_welcome_pending = (
+            not self._initialised
+            and len(self._plugin_list_widget.installed_plugins) == 0
+            and not disable_startup_widget
+        )
         self._plugin_list_widget.populate_download_plugins(
             self._select_release_type_widget.isChecked()
         )
-        if (
-            not self._initialised
-            and len(self._plugin_list_widget.installed_plugins) == 0
-        ):
-            disable_startup_widget = bool(
-                os.getenv('FTRACK_CONNECT_DISABLE_STARTUP_WIDGET', False)
-            )
-            if not disable_startup_widget:
-                self.show_welcome.emit(
-                    self._plugin_list_widget.downloadable_plugin_count
-                )
+
+    def _on_download_plugins_populated(self):
+        """Downloadable plugins are known, show welcome dialog if pending."""
+        if not self._show_welcome_pending:
+            return
+        self._show_welcome_pending = False
+        self.show_welcome.emit(
+            self._plugin_list_widget.downloadable_plugin_count
+        )
 
     def _on_show_welcome_callback(self, downloadable_plugin_count):
         # Show dialog were user can choose to install all available plugins
@@ -255,8 +266,8 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         if downloadable_plugin_count == 0:
             QtWidgets.QMessageBox.warning(
                 self,
-                'Plugin Manager',
-                'No plugins installed and no downloadable plugins found! Please check your configuration.',
+                "Plugin Manager",
+                "No plugins installed and no downloadable plugins found! Please check your configuration.",
             )
             return
 
@@ -277,7 +288,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._apply_button.setVisible(True)
 
     def _on_install_all_callback(self, on_plugin_installed_callback):
-        '''Install all downloadable plugins, to be called from welcome dialog'''
+        """Install all downloadable plugins, to be called from welcome dialog"""
         num_items = self._plugin_list_widget.plugin_model.rowCount()
         for i in range(num_items):
             item = self._plugin_list_widget.plugin_model.item(i)
@@ -289,19 +300,19 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         self._reset_button.click()
 
     def _show_user_message_done(self):
-        '''Show final message to the user.'''
-        self._blocking_overlay.message = '<h2>Installation finished!</h2>'
+        """Show final message to the user."""
+        self._blocking_overlay.message = "<h2>Installation finished!</h2>"
         self._blocking_overlay.icon_data = qta.icon(
-            'mdi6.check', color='#FFDD86', scale_factor=1.2
+            "mdi6.check", color="#FFDD86", scale_factor=1.2
         )
         self._blocking_overlay.confirm_button.show()
         self._blocking_overlay.show()
 
     def _show_user_message_failed(self, reason):
-        '''Show final message to the user.'''
-        self._blocking_overlay.message = '<h2>Installation FAILED!</h2>'
+        """Show final message to the user."""
+        self._blocking_overlay.message = "<h2>Installation FAILED!</h2>"
         self._blocking_overlay.icon_data = qta.icon(
-            'mdi6.close', color='#FF8686', scale_factor=1.2
+            "mdi6.close", color="#FF8686", scale_factor=1.2
         )
         self._blocking_overlay.set_reason(reason)
         self._blocking_overlay.confirm_button.show()
@@ -309,42 +320,42 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     def _reset_overlay(self):
         self._reset_plugin_list()
-        self._busy_overlay.message = '<h2>Updating....</h2>'
+        self._busy_overlay.message = "<h2>Updating....</h2>"
 
     def _update_overlay(self, item):
-        '''Update the overlay'''
+        """Update the overlay"""
         self._counter += 1
 
         self._busy_overlay.message = (
-            f'<h2>Installing {self._counter} of {len(self._plugins_to_install)} plugins...</h2></br>'
-            f'{item.data(ROLES.PLUGIN_NAME)}, Version {str(item.data(ROLES.PLUGIN_VERSION))}'
+            f"<h2>Installing {self._counter} of {len(self._plugins_to_install)} plugins...</h2></br>"
+            f"{item.data(ROLES.PLUGIN_NAME)}, Version {str(item.data(ROLES.PLUGIN_VERSION))}"
         )
 
     def _get_incompatible_plugin_names(self):
         result = []
         for plugin in self.installed_plugins:
-            if plugin['incompatible']:
-                result.append(plugin['name'])
+            if plugin["incompatible"]:
+                result.append(plugin["name"])
         return result
 
     def _get_deprecated_plugin_names(self):
         result = []
         for plugin in self.installed_plugins:
-            if plugin['deprecated']:
-                result.append(plugin['name'])
+            if plugin["deprecated"]:
+                result.append(plugin["name"])
         return result
 
     def _on_apply_changes(self):
-        '''User wants to apply the updates, warn about conflicting plugins.'''
+        """User wants to apply the updates, warn about conflicting plugins."""
         incompatible_plugin_names = self._get_incompatible_plugin_names()
         deprecated_plugins = self._get_deprecated_plugin_names()
         if incompatible_plugin_names:
             msgbox = QtWidgets.QMessageBox(
                 QtWidgets.QMessageBox.Icon.Warning,
-                'Warning',
-                'The following conflicting and incompatible plugins are installed and will be ignored by Connect'
-                ':\n\n{}\n\nClean up and archive them?\n\n Note: you might want to keep them if you are still using Connect 2'.format(
-                    '\n'.join(incompatible_plugin_names)
+                "Warning",
+                "The following conflicting and incompatible plugins are installed and will be ignored by Connect"
+                ":\n\n{}\n\nClean up and archive them?\n\n Note: you might want to keep them if you are still using Connect 2".format(
+                    "\n".join(incompatible_plugin_names)
                 ),
                 buttons=QtWidgets.QMessageBox.StandardButton.Yes
                 | QtWidgets.QMessageBox.StandardButton.No
@@ -361,11 +372,11 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
         if deprecated_plugins:
             msgbox = QtWidgets.QMessageBox(
                 QtWidgets.QMessageBox.Icon.Warning,
-                'Warning',
-                'The following deprecated plugins are installed'
-                ':\n\n{}\n\nClean up and archive them?\n\nNote: they might still function, please '
-                'check release notes for further details. You might want to keep them if you are still using Connect 2'.format(
-                    '\n'.join(deprecated_plugins)
+                "Warning",
+                "The following deprecated plugins are installed"
+                ":\n\n{}\n\nClean up and archive them?\n\nNote: they might still function, please "
+                "check release notes for further details. You might want to keep them if you are still using Connect 2".format(
+                    "\n".join(deprecated_plugins)
                 ),
                 buttons=QtWidgets.QMessageBox.StandardButton.Yes
                 | QtWidgets.QMessageBox.StandardButton.No
@@ -383,7 +394,7 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
 
     @asynchronous
     def on_apply_changes_confirmed_callback(self, archive_plugins):
-        '''Will process all the selected plugins.'''
+        """Will process all the selected plugins."""
         # Check if any conflicting plugins are installed.
         self.installation_started.emit()
         try:
@@ -398,14 +409,14 @@ class PluginManager(ftrack_connect.ui.application.ConnectWidget):
             self.installation_done.emit()
             self._emit_downloaded_plugins(self._plugins_to_install)
             self._reset_plugin_list()
-        except:
+        except Exception:
             # Do not leave the overlay in a bad state.
             self.installation_failed.emit(traceback.format_exc())
 
     def get_debug_information(self):
-        '''Append all identified plugins as debug information.'''
+        """Append all identified plugins as debug information."""
         result = super(PluginManager, self).get_debug_information()
-        result['installed_plugins'] = []
+        result["installed_plugins"] = []
         for item in self.items:
-            result['installed_plugins'].append(item.text())
+            result["installed_plugins"].append(item.text())
         return result

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -1,8 +1,6 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2024 ftrack
-import re
 import os
-import platformdirs
 from packaging.version import parse as parse_version
 from urllib.request import urlopen
 import json
@@ -36,27 +34,58 @@ from ftrack_connect.plugin_manager.processor import (
 logger = logging.getLogger(__name__)
 
 
+class GithubReleaseFetcherSignals(QtCore.QObject):
+    """Signals for the GitHub release fetcher worker."""
+
+    finished = QtCore.Signal(list)  # emits list of releases
+    error = QtCore.Signal(str)  # emits error message
+
+
+class GithubReleaseFetcher(QtCore.QRunnable):
+    """Background worker to fetch GitHub releases without blocking UI."""
+
+    def __init__(self, url, prereleases=False):
+        super(GithubReleaseFetcher, self).__init__()
+        self.url = url
+        self.prereleases = prereleases
+        self.signals = GithubReleaseFetcherSignals()
+
+    def run(self):
+        """Execute the GitHub API call in background thread."""
+        try:
+            logger.debug(
+                f"Fetching GitHub releases in background from: {self.url}"
+            )
+            releases = fetch_github_releases(
+                self.url, prereleases=self.prereleases
+            )
+            self.signals.finished.emit(releases)
+        except Exception as e:
+            logger.error(f"Failed to fetch GitHub releases: {e}")
+            self.signals.error.emit(str(e))
+
+
 class DndPluginList(QtWidgets.QFrame):
-    '''Plugin list widget'''
+    """Plugin list widget"""
 
     @property
     def proxy_model(self):
-        '''Return proxy model.'''
+        """Return proxy model."""
         return self._proxy_model
 
     @property
     def plugin_model(self):
-        '''Return plugin model.'''
+        """Return plugin model."""
         return self._plugin_model
 
     @property
     def installed_plugins(self):
-        '''Return installed plugin count.'''
+        """Return installed plugin count."""
         return self._installed_plugins
 
     @property
     def downloadable_plugin_count(self):
-        '''Return downloadable plugin count.'''
+        """Return downloadable plugin count."""
         return self._downloadable_plugin_count
 
     def __init__(self, parent=None):
@@ -100,24 +129,24 @@ class DndPluginList(QtWidgets.QFrame):
     # custom methods
     @qt_main_thread
     def _add_plugin(self, plugin_data, status=STATUSES.NEW):
-        '''Add provided *plugin_data* as plugin with given *status*.'''
+        """Add provided *plugin_data* as plugin with given *status*."""
 
         if not plugin_data:
             return
 
         # Check platform
         platform = get_platform_identifier()
-        destination_filename = os.path.basename(plugin_data['path'])
-        if destination_filename.lower().endswith('.zip'):
+        destination_filename = os.path.basename(plugin_data["path"])
+        if destination_filename.lower().endswith(".zip"):
             destination_filename = destination_filename[:-4]
-        if plugin_data['platform'] != 'noarch':
-            if plugin_data['platform'] != platform:
+        if plugin_data["platform"] != "noarch":
+            if plugin_data["platform"] != platform:
                 # Not our platform, ask user if they want to install anyway
                 msgbox = QtWidgets.QMessageBox(
                     QtWidgets.QMessageBox.Icon.Warning,
-                    'Warning',
-                    'This plugin is not compatible with your platform:'
-                    f':\n\n{destination_filename}\n\nProceed install anyway?',
+                    "Warning",
+                    "This plugin is not compatible with your platform:"
+                    f":\n\n{destination_filename}\n\nProceed install anyway?",
                     buttons=QtWidgets.QMessageBox.StandardButton.Yes
                     | QtWidgets.QMessageBox.StandardButton.No
                     | QtWidgets.QMessageBox.StandardButton.Cancel,
@@ -129,7 +158,7 @@ class DndPluginList(QtWidgets.QFrame):
                 elif answer == QtWidgets.QMessageBox.StandardButton.No:
                     return  # Skip this one, but proceed
                 elif answer == QtWidgets.QMessageBox.StandardButton.Cancel:
-                    raise Exception('Plugin installation cancelled by user.')
+                    raise Exception("Plugin installation cancelled by user.")
 
             if destination_filename.endswith(f'-{plugin_data["platform"]}'):
                 destination_filename = destination_filename[
@@ -137,8 +166,8 @@ class DndPluginList(QtWidgets.QFrame):
                 ]
 
         # create new plugin item and populate it with data
-        plugin_id = str(hash(plugin_data['name']))
-        plugin_data['id'] = plugin_id
+        plugin_id = str(hash(plugin_data["name"]))
+        plugin_data["id"] = plugin_id
 
         plugin_item = QtGui.QStandardItem()
 
@@ -151,22 +180,22 @@ class DndPluginList(QtWidgets.QFrame):
             f'{plugin_data["name"]} | {plugin_data["version"]}'
         )
         plugin_item.setData(status, ROLES.PLUGIN_STATUS)
-        plugin_item.setData(str(plugin_data['name']), ROLES.PLUGIN_NAME)
-        new_plugin_version = parse_version(plugin_data['version'])
+        plugin_item.setData(str(plugin_data["name"]), ROLES.PLUGIN_NAME)
+        new_plugin_version = parse_version(plugin_data["version"])
         plugin_item.setData(new_plugin_version, ROLES.PLUGIN_VERSION)
         plugin_item.setData(plugin_id, ROLES.PLUGIN_ID)
         plugin_item.setIcon(STATUS_ICONS[status])
 
-        if plugin_data['incompatible'] or plugin_data['deprecated']:
-            if plugin_data['incompatible']:
+        if plugin_data["incompatible"] or plugin_data["deprecated"]:
+            if plugin_data["incompatible"]:
                 plugin_item.setIcon(
-                    QtGui.QIcon(qta.icon('mdi6.alert-circle-outline'))
+                    QtGui.QIcon(qta.icon("mdi6.alert-circle-outline"))
                 )
-                plugin_item.setText(f'{plugin_item.text()} [Incompatible]')
+                plugin_item.setText(f"{plugin_item.text()} [Incompatible]")
                 plugin_item.setData(True, ROLES.PLUGIN_INCOMPATIBLE)
             else:
-                plugin_item.setIcon(QtGui.QIcon(qta.icon('mdi6.alert')))
-                plugin_item.setText(f'{plugin_item.text()} [Deprecated]')
+                plugin_item.setIcon(QtGui.QIcon(qta.icon("mdi6.alert")))
+                plugin_item.setText(f"{plugin_item.text()} [Deprecated]")
                 plugin_item.setData(True, ROLES.PLUGIN_DEPRECATED)
         else:
             plugin_item.setIcon(STATUS_ICONS[status])
@@ -178,14 +207,14 @@ class DndPluginList(QtWidgets.QFrame):
             # add new plugin
             if status == STATUSES.INSTALLED:
                 plugin_item.setData(
-                    plugin_data['path'], ROLES.PLUGIN_INSTALLED_PATH
+                    plugin_data["path"], ROLES.PLUGIN_INSTALLED_PATH
                 )
                 plugin_item.setEnabled(False)
                 plugin_item.setCheckable(False)
 
             elif status in [STATUSES.NEW, STATUSES.DOWNLOAD]:
                 plugin_item.setData(
-                    plugin_data['path'], ROLES.PLUGIN_SOURCE_PATH
+                    plugin_data["path"], ROLES.PLUGIN_SOURCE_PATH
                 )
                 destination_path = os.path.join(
                     self.default_install_plugin_directory, destination_filename
@@ -215,7 +244,7 @@ class DndPluginList(QtWidgets.QFrame):
                 return
 
             # update stored item.
-            stored_item.setText(f'{stored_item.text()} > {new_plugin_version}')
+            stored_item.setText(f"{stored_item.text()} > {new_plugin_version}")
             stored_item.setData(STATUSES.UPDATE, ROLES.PLUGIN_STATUS)
             stored_item.setIcon(STATUS_ICONS[STATUSES.UPDATE])
             destination_path = os.path.join(
@@ -224,7 +253,7 @@ class DndPluginList(QtWidgets.QFrame):
             stored_item.setData(
                 destination_path, ROLES.PLUGIN_DESTINATION_PATH
             )
-            stored_item.setData(plugin_data['path'], ROLES.PLUGIN_SOURCE_PATH)
+            stored_item.setData(plugin_data["path"], ROLES.PLUGIN_SOURCE_PATH)
 
             stored_item.setData(new_plugin_version, ROLES.PLUGIN_VERSION)
 
@@ -234,18 +263,18 @@ class DndPluginList(QtWidgets.QFrame):
             stored_item.setCheckState(QtCore.Qt.CheckState.Checked)
 
     def plugin_is_available(self, plugin_data):
-        '''Return item from *plugin_data* if found.'''
+        """Return item from *plugin_data* if found."""
         num_items = self._plugin_model.rowCount()
         for i in range(num_items):
             item = self._plugin_model.item(i)
             item_id = item.data(ROLES.PLUGIN_ID)
-            if item_id == plugin_data['id']:
+            if item_id == plugin_data["id"]:
                 return item
         return None
 
     def _remove_plugin(self, plugin_name):
-        '''Remove the plugin *plugin_name* from plugin list (not disk),
-        if succeeded/found True will be returned, False otherwise.'''
+        """Remove the plugin *plugin_name* from plugin list (not disk),
+        if succeeded/found True will be returned, False otherwise."""
         num_items = self._plugin_model.rowCount()
         for i in range(num_items):
             item = self._plugin_model.item(i)
@@ -257,7 +286,7 @@ class DndPluginList(QtWidgets.QFrame):
         return False
 
     def populate_installed_plugins(self, plugins):
-        '''Populate model with installed plugins.'''
+        """Populate model with installed plugins."""
         self._installed_plugin_count = 0
         self._plugin_model.clear()
 
@@ -272,13 +301,13 @@ class DndPluginList(QtWidgets.QFrame):
                 # Show message box to user
                 QtWidgets.QMessageBox.warning(
                     self,
-                    'Warning',
-                    f'The following plugin failed to load:\n\n{plugin}\n\n{e}',
+                    "Warning",
+                    f"The following plugin failed to load:\n\n{plugin}\n\n{e}",
                 )
-                logger.warning(f'Failed to add plugin {plugin}: ')
+                logger.warning(f"Failed to add plugin {plugin}: ")
 
     def populate_download_plugins(self, prereleases=False):
-        '''Populate model with remotely configured plugins.'''
+        """Populate model with remotely configured plugins."""
         # Read plugins from json config url if set by user
         self._downloadable_plugin_count = 0
         if self._json_config_url:
@@ -287,41 +316,59 @@ class DndPluginList(QtWidgets.QFrame):
             response = urlopen(self._json_config_url)
             response_json = json.loads(response.read())
 
-            for link in response_json['integrations']:
+            for link in response_json["integrations"]:
                 self._add_plugin(get_plugin_data(link), STATUSES.DOWNLOAD)
                 self._downloadable_plugin_count += 1
         else:
             url = os.environ.get(
-                'FTRACK_CONNECT_GITHUB_RELEASES_URL',
+                "FTRACK_CONNECT_GITHUB_RELEASES_URL",
                 DEFAULT_INTEGRATIONS_REPO_URL,
             )
-            if url.lower() in ['none', 'disable', '0', 'false']:
+            if url.lower() in ["none", "disable", "0", "false"]:
                 logger.warning(
-                    'Not attempting to fetch releases from Github, '
-                    'disabled by environment variable.'
+                    "Not attempting to fetch releases from Github, "
+                    "disabled by environment variable."
                 )
                 return
-            # Read latest releases from ftrack integrations repository
-            releases = fetch_github_releases(url, prereleases=prereleases)
 
-            for release in releases:
-                self._add_plugin(
-                    get_plugin_data(release['url']), STATUSES.DOWNLOAD
-                )
-                self._downloadable_plugin_count += 1
+            # Fetch releases asynchronously to avoid blocking the UI
+            logger.info("Starting background fetch of GitHub releases...")
+            worker = GithubReleaseFetcher(url, prereleases=prereleases)
+            worker.signals.finished.connect(self._on_github_releases_fetched)
+            worker.signals.error.connect(self._on_github_fetch_error)
+            QtCore.QThreadPool.globalInstance().start(worker)
+
+    def _on_github_releases_fetched(self, releases):
+        """Handle GitHub releases fetched in background thread."""
+        logger.info(
+            f"Successfully fetched {len(releases)} releases from GitHub"
+        )
+        for release in releases:
+            self._add_plugin(
+                get_plugin_data(release["url"]), STATUSES.DOWNLOAD
+            )
+            self._downloadable_plugin_count += 1
+        logger.debug(
+            f"Added {self._downloadable_plugin_count} downloadable plugins"
+        )
+
+    def _on_github_fetch_error(self, error_message):
+        """Handle error during GitHub release fetch."""
+        logger.error(f"GitHub release fetch failed: {error_message}")
+        # UI continues to work, just without downloadable plugins
 
     def archive_legacy_plugin(self, plugin_name):
-        '''Move legacy plugin identified by *plugin_name* to archive folder'''
+        """Move legacy plugin identified by *plugin_name* to archive folder"""
         install_path = os.path.join(
             self.default_install_plugin_directory, plugin_name
         )
-        logger.debug(f'Archiving legacy plugin: {install_path}')
+        logger.debug(f"Archiving legacy plugin: {install_path}")
         if os.path.exists(install_path) and os.path.isdir(install_path):
             archive_base_path = os.path.relpath(
                 os.path.join(
                     self.default_install_plugin_directory,
-                    '..',
-                    'ftrack-connect-plugins-ARCHIVED',
+                    "..",
+                    "ftrack-connect-plugins-ARCHIVED",
                 )
             )
             archive_path = os.path.join(archive_base_path, plugin_name)
@@ -333,59 +380,59 @@ class DndPluginList(QtWidgets.QFrame):
                 # Move it to archive
                 try:
                     logger.warning(
-                        f'Attempting to archive plugin: {install_path} > {archive_path}'
+                        f"Attempting to archive plugin: {install_path} > {archive_path}"
                     )
                     shutil.move(install_path, archive_path)
-                    logger.warning(f'Archived plugin: {install_path}')
+                    logger.warning(f"Archived plugin: {install_path}")
                     remove = False
                 except Exception as e:
                     logger.exception(e)
                     logger.error(
-                        f'Plugin archive failed, please check permissions! {e}'
+                        f"Plugin archive failed, please check permissions! {e}"
                     )
             else:
-                logger.warning(f'Plugin is already archived @ {archive_path}')
+                logger.warning(f"Plugin is already archived @ {archive_path}")
             if remove:
-                logger.warning(f'Attempting to remove plugin: {install_path}')
+                logger.warning(f"Attempting to remove plugin: {install_path}")
                 try:
                     shutil.rmtree(
                         install_path, ignore_errors=False, onerror=None
                     )
-                    logger.warning(f'Removed plugin: {install_path}')
+                    logger.warning(f"Removed plugin: {install_path}")
                 except Exception as e:
                     logger.exception(e)
                     logger.error(
-                        f'Plugin removal failed, please check permissions! {e}'
+                        f"Plugin removal failed, please check permissions! {e}"
                     )
 
     def _process_mime_data(self, mime_data):
-        '''Return a list of valid filepaths.'''
+        """Return a list of valid filepaths."""
         validPaths = []
 
         if not mime_data.hasUrls():
             QtWidgets.QMessageBox.warning(
                 self,
-                'Invalid file',
-                'Invalid file: the dropped item is not a valid file.',
+                "Invalid file",
+                "Invalid file: the dropped item is not a valid file.",
             )
             return validPaths
 
         for path in mime_data.urls():
             local_path = path.toLocalFile()
             if os.path.isfile(local_path):
-                if local_path.endswith('.zip'):
+                if local_path.endswith(".zip"):
                     validPaths.append(local_path)
 
         return validPaths
 
     def dragEnterEvent(self, event):
-        '''Override dragEnterEvent and accept all events.'''
+        """Override dragEnterEvent and accept all events."""
         event.setDropAction(QtCore.Qt.DropAction.CopyAction)
         event.accept()
-        self._set_drop_zone_state('active')
+        self._set_drop_zone_state("active")
 
     def dropEvent(self, event):
-        '''Handle dropped file event.'''
+        """Handle dropped file event."""
         self._set_drop_zone_state()
 
         paths = self._process_mime_data(event.mimeData())
@@ -393,19 +440,19 @@ class DndPluginList(QtWidgets.QFrame):
         for path in paths:
             # Remove existing one
             plugin_data = get_plugin_data(path)
-            self._remove_plugin(plugin_data['name'])
+            self._remove_plugin(plugin_data["name"])
             self._add_plugin(plugin_data, STATUSES.NEW)
 
         event.accept()
         self._set_drop_zone_state()
 
-    def _set_drop_zone_state(self, state='default'):
-        '''Set drop zone state to *state*.
+    def _set_drop_zone_state(self, state="default"):
+        """Set drop zone state to *state*.
 
         *state* should be 'default', 'active' or 'invalid'.
 
-        '''
-        self.setProperty('ftrackDropZoneState', state)
+        """
+        self.setProperty("ftrackDropZoneState", state)
         self.style().unpolish(self)
         self.style().polish(self)
         self.update()

--- a/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
+++ b/apps/connect/source/ftrack_connect/plugin_manager/plugin_list.py
@@ -61,12 +61,16 @@ class GithubReleaseFetcher(QtCore.QRunnable):
             )
             self.signals.finished.emit(releases)
         except Exception as e:
-            logger.error(f"Failed to fetch GitHub releases: {e}")
+            logger.exception(f"Failed to fetch GitHub releases: {e}")
             self.signals.error.emit(str(e))
 
 
 class DndPluginList(QtWidgets.QFrame):
     """Plugin list widget"""
+
+    # Emitted when population of downloadable plugins has finished and
+    # downloadable_plugin_count is final.
+    download_plugins_populated = QtCore.Signal()
 
     @property
     def proxy_model(self):
@@ -103,6 +107,7 @@ class DndPluginList(QtWidgets.QFrame):
         self._proxy_model = None
         self._installed_plugin_count = 0
         self._downloadable_plugin_count = 0
+        self._release_fetcher = None
 
         self.setAcceptDrops(True)
 
@@ -146,7 +151,7 @@ class DndPluginList(QtWidgets.QFrame):
                     QtWidgets.QMessageBox.Icon.Warning,
                     "Warning",
                     "This plugin is not compatible with your platform:"
-                    f":\n\n{destination_filename}\n\nProceed install anyway?",
+                    f"\n\n{destination_filename}\n\nProceed install anyway?",
                     buttons=QtWidgets.QMessageBox.StandardButton.Yes
                     | QtWidgets.QMessageBox.StandardButton.No
                     | QtWidgets.QMessageBox.StandardButton.Cancel,
@@ -319,6 +324,7 @@ class DndPluginList(QtWidgets.QFrame):
             for link in response_json["integrations"]:
                 self._add_plugin(get_plugin_data(link), STATUSES.DOWNLOAD)
                 self._downloadable_plugin_count += 1
+            self.download_plugins_populated.emit()
         else:
             url = os.environ.get(
                 "FTRACK_CONNECT_GITHUB_RELEASES_URL",
@@ -329,6 +335,7 @@ class DndPluginList(QtWidgets.QFrame):
                     "Not attempting to fetch releases from Github, "
                     "disabled by environment variable."
                 )
+                self.download_plugins_populated.emit()
                 return
 
             # Fetch releases asynchronously to avoid blocking the UI
@@ -336,26 +343,49 @@ class DndPluginList(QtWidgets.QFrame):
             worker = GithubReleaseFetcher(url, prereleases=prereleases)
             worker.signals.finished.connect(self._on_github_releases_fetched)
             worker.signals.error.connect(self._on_github_fetch_error)
+            # Keep a reference so worker and its signals are not garbage
+            # collected before the queued signals are delivered, and to be
+            # able to identify results from superseded fetches.
+            self._release_fetcher = worker
             QtCore.QThreadPool.globalInstance().start(worker)
 
     def _on_github_releases_fetched(self, releases):
         """Handle GitHub releases fetched in background thread."""
+        if (
+            self._release_fetcher is None
+            or self.sender() is not self._release_fetcher.signals
+        ):
+            # Result from a superseded fetch, discard
+            return
+        self._release_fetcher = None
         logger.info(
             f"Successfully fetched {len(releases)} releases from GitHub"
         )
-        for release in releases:
-            self._add_plugin(
-                get_plugin_data(release["url"]), STATUSES.DOWNLOAD
+        try:
+            for release in releases:
+                self._add_plugin(
+                    get_plugin_data(release["url"]), STATUSES.DOWNLOAD
+                )
+                self._downloadable_plugin_count += 1
+            logger.debug(
+                f"Added {self._downloadable_plugin_count} downloadable"
+                " plugins"
             )
-            self._downloadable_plugin_count += 1
-        logger.debug(
-            f"Added {self._downloadable_plugin_count} downloadable plugins"
-        )
+        finally:
+            self.download_plugins_populated.emit()
 
     def _on_github_fetch_error(self, error_message):
         """Handle error during GitHub release fetch."""
+        if (
+            self._release_fetcher is None
+            or self.sender() is not self._release_fetcher.signals
+        ):
+            # Error from a superseded fetch, discard
+            return
+        self._release_fetcher = None
         logger.error(f"GitHub release fetch failed: {error_message}")
         # UI continues to work, just without downloadable plugins
+        self.download_plugins_populated.emit()
 
     def archive_legacy_plugin(self, plugin_name):
         """Move legacy plugin identified by *plugin_name* to archive folder"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Asynchronous plugin release fetching to keep the UI responsive.
  * Welcome prompt now defers until remote plugin info is available.

* **Improvements**
  * Clearer compatibility and deprecated-plugin warnings and updated UI text.
  * Install flow now reports failures cleanly and prevents leaving the UI in a bad state.

* **Bug Fixes**
  * Improved error handling during plugin fetching—app remains usable if remote fetch fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->