### PR TITLE
feat: add projections to optimize queries

### DIFF
--- a/apps/connect/source/ftrack_connect/action_launcher/actions.py
+++ b/apps/connect/source/ftrack_connect/action_launcher/actions.py
@@ -28,24 +28,24 @@ from ftrack_connect.utils.preferences import (
 
 
 class ActionBase(dict):
-    '''Wrapper for an action dict.'''
+    """Wrapper for an action dict."""
 
     def __init__(self, *args, **kwargs):
-        '''Initialise the action.'''
+        """Initialise the action."""
         super(ActionBase, self).__init__(*args, **kwargs)
 
 
 class ActionSection(flow_layout.ScrollingFlowWidget):
-    '''Action list view.'''
+    """Action list view."""
 
     #: Emitted before an action is launched with action
-    beforeActionLaunch = QtCore.Signal(dict, name='beforeActionLaunch')
+    beforeActionLaunch = QtCore.Signal(dict, name="beforeActionLaunch")
 
     #: Emitted after an action has been launched with action and results
-    actionLaunched = QtCore.Signal(dict, list, name='actionLaunched')
+    actionLaunched = QtCore.Signal(dict, list, name="actionLaunched")
 
     def clear(self):
-        '''Remove all actions from section.'''
+        """Remove all actions from section."""
         items = self.findChildren(action_item.ActionItem)
         for item in items:
             # item.setParent(None)
@@ -53,7 +53,7 @@ class ActionSection(flow_layout.ScrollingFlowWidget):
             del item
 
     def add_actions(self, actions):
-        '''Add *actions* to section'''
+        """Add *actions* to section"""
         for item in actions:
             item = action_item.ActionItem(self.session, item, parent=self)
             item.actionLaunched.connect(self._on_action_launched_callback)
@@ -63,42 +63,42 @@ class ActionSection(flow_layout.ScrollingFlowWidget):
             self.addWidget(item)
 
     def _on_action_launched_callback(self, action, results):
-        '''Forward actionLaunched signal.'''
+        """Forward actionLaunched signal."""
         self.actionLaunched.emit(action, results)
 
     def _on_before_action_launched_callback(self, action):
-        '''Forward beforeActionLaunch signal.'''
+        """Forward beforeActionLaunch signal."""
         self.beforeActionLaunch.emit(action)
 
 
 class Actions(QtWidgets.QWidget):
-    '''Actions widget. Displays and runs actions with a selectable context.'''
+    """Actions widget. Displays and runs actions with a selectable context."""
 
-    RECENT_METADATA_KEY = 'ftrack_recent_actions'
+    RECENT_METADATA_KEY = "ftrack_recent_actions"
     RECENT_ACTIONS_LENGTH = 20
     ACTION_LAUNCH_MESSAGE_TIMEOUT = 3
 
     #: Emitted when recent actions has been modified
-    recent_actions_changed = QtCore.Signal(name='recentActionsChanged')
-    actions_loaded = QtCore.Signal(object, name='actionsLoaded')
+    recent_actions_changed = QtCore.Signal(name="recentActionsChanged")
+    actions_loaded = QtCore.Signal(object, name="actionsLoaded")
     actions_loading = QtCore.Signal()
 
     @property
     def session(self):
-        '''Return current session.'''
+        """Return current session."""
         return self._session
 
     @property
     def actions(self):
-        '''Return actions.'''
+        """Return actions."""
         return self._actions
 
     def __init__(self, session, parent=None):
-        '''Initiate a actions view.'''
+        """Initiate a actions view."""
         super(Actions, self).__init__(parent)
 
         self.logger = logging.getLogger(
-            __name__ + '.' + self.__class__.__name__
+            __name__ + "." + self.__class__.__name__
         )
         self._session = session
 
@@ -113,10 +113,10 @@ class Actions(QtWidgets.QWidget):
 
         self._entity_selector.setFixedHeight(50)
         self._entity_selector.entityChanged.connect(self._on_entity_changed)
-        layout.addWidget(QtWidgets.QLabel('Select action context'))
+        layout.addWidget(QtWidgets.QLabel("Select action context"))
         layout.addWidget(self._entity_selector)
 
-        self._recent_label = QtWidgets.QLabel('Recent')
+        self._recent_label = QtWidgets.QLabel("Recent")
         layout.addWidget(self._recent_label)
         self._recent_section = ActionSection(self.session, self)
         self._recent_section.setFixedHeight(150)
@@ -128,7 +128,7 @@ class Actions(QtWidgets.QWidget):
         )
         layout.addWidget(self._recent_section)
 
-        self._all_label = QtWidgets.QLabel('Discovering actions..')
+        self._all_label = QtWidgets.QLabel("Discovering actions..")
         self._all_label.setWordWrap(True)
         self._all_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self._all_label)
@@ -142,7 +142,7 @@ class Actions(QtWidgets.QWidget):
         layout.addWidget(self._all_section)
 
         self._overlay = overlay.BusyOverlay(
-            parent=self, message='Launching...'
+            parent=self, message="Launching..."
         )
         self._overlay.setVisible(False)
 
@@ -156,16 +156,16 @@ class Actions(QtWidgets.QWidget):
         self._update_recent_actions()
 
     def _on_before_action_launched_callback(self, action):
-        '''Before action is launched, show busy overlay with message..'''
-        self.logger.debug(f'Before action launched: {action}')
+        """Before action is launched, show busy overlay with message.."""
+        self.logger.debug(f"Before action launched: {action}")
 
         rise_message = None
         launcher_prefs = get_connect_preferences()
-        known_rosetta_apps = launcher_prefs.get('known_rosetta_apps', [])
+        known_rosetta_apps = launcher_prefs.get("known_rosetta_apps", [])
         if (
-            platform.system().lower() == 'darwin'
-            and action.get('rosetta')
-            and action['actionIdentifier'] not in known_rosetta_apps
+            platform.system().lower() == "darwin"
+            and action.get("rosetta")
+            and action["actionIdentifier"] not in known_rosetta_apps
         ):
             import subprocess
 
@@ -177,22 +177,22 @@ class Actions(QtWidgets.QWidget):
             )
 
             # Check if the output is silicon.
-            if result.stdout.strip() == '1':
+            if result.stdout.strip() == "1":
                 rise_message = (
-                    'You are on Apple silicon computer, the '
-                    'integration for the application you are launching '
-                    'requires to be launched using Rosetta. '
+                    "You are on Apple silicon computer, the "
+                    "integration for the application you are launching "
+                    "requires to be launched using Rosetta. "
                     'Please set "opening using Rosetta" checkbox '
-                    'on your app before launching or change the '
-                    'launch configuration. Get More info at: '
-                    'https://support.apple.com/en-us/HT211861#needsrosetta'
+                    "on your app before launching or change the "
+                    "launch configuration. Get More info at: "
+                    "https://support.apple.com/en-us/HT211861#needsrosetta"
                 )
                 self.logger.debug(rise_message)
 
         if rise_message:
             message_box = QtWidgets.QMessageBox(
                 QtWidgets.QMessageBox.Icon.Warning,
-                'Warning',
+                "Warning",
                 rise_message,
                 buttons=QtWidgets.QMessageBox.Ok,
             )
@@ -204,8 +204,8 @@ class Actions(QtWidgets.QWidget):
             # Check if OK was clicked and if the checkbox was checked
             if response == QtWidgets.QMessageBox.Ok:
                 if checkbox.isChecked():
-                    known_rosetta_apps.append(action['actionIdentifier'])
-                    launcher_prefs['known_rosetta_apps'] = known_rosetta_apps
+                    known_rosetta_apps.append(action["actionIdentifier"])
+                    launcher_prefs["known_rosetta_apps"] = known_rosetta_apps
                     write_connect_prefs_file_path(launcher_prefs)
 
         message = (
@@ -217,19 +217,19 @@ class Actions(QtWidgets.QWidget):
         self._overlay.setVisible(True)
 
     def _on_action_launched_callback(self, action, results):
-        '''On action launched, save action and add it to top of list.'''
-        self.logger.debug(f'Action launched: {action}')
-        self._add_recent_action(action['label'])
-        self._move_to_front(self._recent_actions, action['label'])
+        """On action launched, save action and add it to top of list."""
+        self.logger.debug(f"Action launched: {action}")
+        self._add_recent_action(action["label"])
+        self._move_to_front(self._recent_actions, action["label"])
         self._update_recent_section()
 
         self._show_result_message(results)
 
         validMetadata = [
-            'actionIdentifier',
-            'label',
-            'variant',
-            'applicationIdentifier',
+            "actionIdentifier",
+            "label",
+            "variant",
+            "applicationIdentifier",
         ]
         metadata = {}
         for key, value in action.items():
@@ -243,16 +243,16 @@ class Actions(QtWidgets.QWidget):
             usage_tracker.track("LAUNCHED-CONNECT-ACTION", metadata)
 
     def _show_result_message(self, results):
-        '''Show *results* message in overlay.'''
-        message = 'Launched action'
+        """Show *results* message in overlay."""
+        message = "Launched action"
         try:
             result = results[0]
-            if 'items' in result.keys():
+            if "items" in result.keys():
                 message = (
-                    'Custom UI for actions is not yet supported in Connect.'
+                    "Custom UI for actions is not yet supported in Connect."
                 )
             else:
-                message = result['message']
+                message = result["message"]
         except Exception:
             pass
 
@@ -262,13 +262,13 @@ class Actions(QtWidgets.QWidget):
         self._hide_overlay_after_timeout(self.ACTION_LAUNCH_MESSAGE_TIMEOUT)
 
     def _hide_overlay_after_timeout(self, timeout):
-        '''Hide overlay after *timeout* seconds.'''
+        """Hide overlay after *timeout* seconds."""
         QtCore.QTimer.singleShot(
             timeout * 1000, functools.partial(self._overlay.setVisible, False)
         )
 
     def _context_from_entity(self, entity):
-        '''convert *entity* to list of dicts'''
+        """convert *entity* to list of dicts"""
         context = []
         if not entity:
             return context
@@ -276,18 +276,18 @@ class Actions(QtWidgets.QWidget):
         try:
             context = [
                 {
-                    'entityId': entity['id'],
-                    'entityType': entity.entity_type.lower(),
+                    "entityId": entity["id"],
+                    "entityType": entity.entity_type.lower(),
                 }
             ]
-            self.logger.debug(f'Context changed: {context}')
+            self.logger.debug(f"Context changed: {context}")
         except Exception:
-            self.logger.debug(f'Invalid entity: {entity}')
+            self.logger.debug(f"Invalid entity: {entity}")
 
         return context
 
     def _on_entity_changed(self, entity):
-        '''Load new actions when the context has changed'''
+        """Load new actions when the context has changed"""
         context = self._context_from_entity(entity)
         self._recent_section.clear()
         self._all_section.clear()
@@ -295,12 +295,12 @@ class Actions(QtWidgets.QWidget):
         self._load_actions_for_context(context)
 
     def _update_recent_section(self):
-        '''Clear and update actions in recent section.'''
+        """Clear and update actions in recent section."""
         self._recent_section.clear()
         recent_actions = []
         for recentAction in self._recent_actions:
             for action in self._actions:
-                if action[0]['label'] == recentAction:
+                if action[0]["label"] == recentAction:
                     recent_actions.append(action)
 
         if recent_actions:
@@ -312,52 +312,53 @@ class Actions(QtWidgets.QWidget):
             self._recent_section.hide()
 
     def _update_all_section(self):
-        '''Clear and update actions in all section.'''
+        """Clear and update actions in all section."""
         self._all_section.clear()
         if self._actions:
             self._all_section.add_actions(self._actions)
             self._all_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignLeft)
-            self._all_label.setText('All actions')
+            self._all_label.setText("All actions")
         else:
             self._all_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             self._all_label.setText(
                 '<h2 style="font-weight: medium"> No matching applications or actions was found</h2>'
-                '<p>Try another selection, add some actions and make sure you have the right integrations set up for the applications you want to launch.</p>'
+                "<p>Try another selection, add some actions and make sure you have the right integrations set up for the applications you want to launch.</p>"
             )
 
     def _update_recent_actions(self):
-        '''Retrieve and update recent actions.'''
+        """Retrieve and update recent actions."""
         self._recent_actions = self._get_recent_actions()
         self.recent_actions_changed.emit()
 
     def _get_current_user_id(self):
-        '''Return current user id.'''
+        """Return current user id."""
         if not self._current_user_id:
             user = self.session.query(
-                f'User where username="{self.session.api_user}"'
+                f'select id from User where username="{self.session.api_user}"'
             ).one()
-            self._current_user_id = user['id']
+            self._current_user_id = user["id"]
 
         return self._current_user_id
 
     def _get_recent_actions(self):
-        '''Retrieve recent actions from the server.'''
+        """Retrieve recent actions from the server."""
 
         metadata = self.session.query(
-            f'Metadata where key is "{self.RECENT_METADATA_KEY}" and parent_type is "User" '
+            f"select value from Metadata "
+            f'where key is "{self.RECENT_METADATA_KEY}" and parent_type is "User" '
             f'and parent_id is "{self._get_current_user_id()}"'
         ).first()
 
         recent_actions = []
         if metadata:
             try:
-                recent_actions = json.loads(metadata['value'])
+                recent_actions = json.loads(metadata["value"])
             except ValueError as e:
-                self.logger.warning(f'Error parsing metadata {metadata}: {e}')
+                self.logger.warning(f"Error parsing metadata {metadata}: {e}")
         return recent_actions
 
     def _move_to_front(self, item_list, item):
-        '''Prepend or move *item* to front of *itemList*.'''
+        """Prepend or move *item* to front of *itemList*."""
         try:
             item_list.remove(item)
         except ValueError:
@@ -366,48 +367,48 @@ class Actions(QtWidgets.QWidget):
 
     @asynchronous
     def _add_recent_action(self, action_label):
-        '''Add *actionLabel* to recent actions, persisting the change.'''
+        """Add *actionLabel* to recent actions, persisting the change."""
         recent_actions = self._get_recent_actions()
         self._move_to_front(recent_actions, action_label)
         recent_actions = recent_actions[: self.RECENT_ACTIONS_LENGTH]
         encoded_recent_actions = json.dumps(recent_actions)
 
         self.session.ensure(
-            'Metadata',
+            "Metadata",
             {
-                'parent_type': 'User',
-                'parent_id': self._get_current_user_id(),
-                'key': self.RECENT_METADATA_KEY,
-                'value': encoded_recent_actions,
+                "parent_type": "User",
+                "parent_id": self._get_current_user_id(),
+                "key": self.RECENT_METADATA_KEY,
+                "value": encoded_recent_actions,
             },
-            identifying_keys=['parent_type', 'parent_id', 'key'],
+            identifying_keys=["parent_type", "parent_id", "key"],
         )
 
     # TODO: To re evaluate: breaks in PySide2 2.14, but works on PyQt5 2.15
     # @asynchronous
     def _load_actions_for_context(self, context):
-        '''Obtain new actions synchronously for *context*.'''
+        """Obtain new actions synchronously for *context*."""
         self.actions_loading.emit()
         discovered_actions = []
 
         event = ftrack_api.event.base.Event(
-            topic='ftrack.action.discover', data=dict(selection=context)
+            topic="ftrack.action.discover", data=dict(selection=context)
         )
 
         results = self.session.event_hub.publish(event, synchronous=True)
 
         for result in results:
             if result:
-                for action in result.get('items', []):
+                for action in result.get("items", []):
                     discovered_actions.append(ActionBase(action))
 
         # Sort actions by label
         grouped_actions = []
         for action in discovered_actions:
-            action['selection'] = context
+            action["selection"] = context
             added = False
             for groupedAction in grouped_actions:
-                if action['label'] == groupedAction[0]['label']:
+                if action["label"] == groupedAction[0]["label"]:
                     groupedAction.append(action)
                     added = True
 
@@ -417,7 +418,7 @@ class Actions(QtWidgets.QWidget):
         # Sort actions by label
         grouped_actions = sorted(
             grouped_actions,
-            key=lambda grouped_action: grouped_action[0]['label'].lower(),
+            key=lambda grouped_action: grouped_action[0]["label"].lower(),
         )
 
         self.actions_loaded.emit(grouped_actions)
@@ -431,7 +432,7 @@ class Actions(QtWidgets.QWidget):
         self._overlay.setVisible(False)
 
     def _on_actions_loading_callback(self):
-        message = u'Discovering Actions ....'
+        message = "Discovering Actions ...."
         self._overlay.message = message
         self._overlay.indicator.show()
         self._overlay.setVisible(True)

--- a/apps/connect/source/ftrack_connect/ui/model/entity_tree.py
+++ b/apps/connect/source/ftrack_connect/ui/model/entity_tree.py
@@ -180,7 +180,9 @@ class Root(Item):
     def _fetchChildren(self):
         """Fetch and return new child items."""
         children = []
-        for entity in self._session.query("Project where status is active"):
+        for entity in self._session.query(
+            "select id, full_name, name, object_type from Project where status is active"
+        ):
             children.append(Project(self._session, entity))
 
         return children

--- a/apps/connect/source/ftrack_connect/ui/model/entity_tree.py
+++ b/apps/connect/source/ftrack_connect/ui/model/entity_tree.py
@@ -181,7 +181,7 @@ class Root(Item):
         """Fetch and return new child items."""
         children = []
         for entity in self._session.query(
-            "select id, full_name, name, object_type from Project where status is active"
+            "select id, full_name, name from Project where status is active"
         ):
             children.append(Project(self._session, entity))
 

--- a/apps/connect/source/ftrack_connect/ui/widget/configure_scenario.py
+++ b/apps/connect/source/ftrack_connect/ui/widget/configure_scenario.py
@@ -1,13 +1,12 @@
 # :coding: utf-8
 # :copyright: Copyright (c) 2014-2023 ftrack
 
-import os
 import webbrowser
 
 try:
-    from PySide6 import QtWidgets, QtCore, QtGui, QtSvg
+    from PySide6 import QtWidgets, QtCore
 except ImportError:
-    from PySide2 import QtWidgets, QtCore, QtGui, QtSvg
+    from PySide2 import QtWidgets, QtCore
 
 import qtawesome as qta
 
@@ -19,13 +18,13 @@ from ftrack_connect import load_fonts_resource
 
 
 class ConfigureScenario(QtWidgets.QWidget):
-    '''Configure scenario widget.'''
+    """Configure scenario widget."""
 
     #: Signal to emit when configuration is completed.
     configuration_completed = QtCore.Signal()
 
     def __init__(self, session):
-        '''Instantiate the configure scenario widget.'''
+        """Instantiate the configure scenario widget."""
         super(ConfigureScenario, self).__init__()
 
         load_fonts_resource()
@@ -35,8 +34,8 @@ class ConfigureScenario(QtWidgets.QWidget):
         # the API.
         try:
             session.query(
-                'Setting where name is "storage_scenario" and '
-                'group is "STORAGE"'
+                "select id from Setting "
+                'where name is "storage_scenario" and group is "STORAGE"'
             ).one()
             can_configure_scenario = True
         except ftrack_api.exception.NoResultFoundError:
@@ -49,7 +48,7 @@ class ConfigureScenario(QtWidgets.QWidget):
 
         layout.addSpacing(100)
 
-        cloud_icon = qta.icon('ftrack.cloud-done')
+        cloud_icon = qta.icon("ftrack.cloud-done")
         icon = QtWidgets.QLabel()
         icon.setPixmap(
             cloud_icon.pixmap(
@@ -58,23 +57,23 @@ class ConfigureScenario(QtWidgets.QWidget):
         )
 
         icon.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        icon.setObjectName('icon-label')
+        icon.setObjectName("icon-label")
         layout.addWidget(icon)
 
         layout.addSpacing(50)
 
         label = QtWidgets.QLabel()
-        label.setObjectName('regular-label')
+        label.setObjectName("regular-label")
         text = (
-            'Hi there, Connect needs to be configured so that ftrack can '
-            'store and track your files for you.'
+            "Hi there, Connect needs to be configured so that ftrack can "
+            "store and track your files for you."
         )
 
         if can_configure_scenario is False:
             text += (
-                '<br><br> You do not have the required permission, please ask '
-                'someone with access to system settings in ftrack to '
-                'configure it before you proceed.'
+                "<br><br> You do not have the required permission, please ask "
+                "someone with access to system settings in ftrack to "
+                "configure it before you proceed."
             )
 
         label.setText(text)
@@ -91,13 +90,13 @@ class ConfigureScenario(QtWidgets.QWidget):
 
         layout.addSpacing(20)
 
-        configure_button = QtWidgets.QPushButton(text='Configure now')
-        configure_button.setObjectName('primary')
+        configure_button = QtWidgets.QPushButton(text="Configure now")
+        configure_button.setObjectName("primary")
         configure_button.clicked.connect(self._configure_storage_scenario)
         configure_button.setMinimumHeight(40)
         configure_button.setMaximumWidth(125)
 
-        dismiss_button = QtWidgets.QPushButton(text='Do it later')
+        dismiss_button = QtWidgets.QPushButton(text="Do it later")
         dismiss_button.clicked.connect(self._complete_configuration)
         dismiss_button.setMinimumHeight(40)
         dismiss_button.setMaximumWidth(125)
@@ -112,11 +111,11 @@ class ConfigureScenario(QtWidgets.QWidget):
         layout.addSpacing(20)
 
         label = QtWidgets.QLabel()
-        label.setObjectName('lead-label')
+        label.setObjectName("lead-label")
         label.setText(
-            'If you decide to do this later, some of the functionality in '
-            'ftrack connect and applications started from connect may not '
-            'work as expected until configured.'
+            "If you decide to do this later, some of the functionality in "
+            "ftrack connect and applications started from connect may not "
+            "work as expected until configured."
         )
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         label.setWordWrap(True)
@@ -131,11 +130,11 @@ class ConfigureScenario(QtWidgets.QWidget):
         layout.addStretch(1)
 
         label = QtWidgets.QLabel()
-        label.setObjectName('green-link')
+        label.setObjectName("green-link")
         label.setText(
             '<a style="color: #935BA2;" '
             'href="https://help.ftrack.com/en/articles/1040436-configuring-file-storage"> '
-            'Learn more about storage scenarios.'
+            "Learn more about storage scenarios."
         )
         label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         label.setOpenExternalLinks(True)
@@ -143,20 +142,20 @@ class ConfigureScenario(QtWidgets.QWidget):
         layout.addSpacing(20)
 
         self._subscriber_identifier = session.event_hub.subscribe(
-            'topic=ftrack.storage-scenario.configure-done',
+            "topic=ftrack.storage-scenario.configure-done",
             self._complete_configuration,
         )
         self._session = session
 
     def _complete_configuration(self, event=None):
-        '''Finish configuration.'''
+        """Finish configuration."""
         self._session.event_hub.unsubscribe(self._subscriber_identifier)
         self.configuration_completed.emit()
 
     def _configure_storage_scenario(self):
-        '''Open browser window and go to the configuration page.'''
+        """Open browser window and go to the configuration page."""
         webbrowser.open_new_tab(
-            '{0}/#view=configure_storage_scenario&itemId=newconfigure'.format(
+            "{0}/#view=configure_storage_scenario&itemId=newconfigure".format(
                 self._session.server_url
             )
         )


### PR DESCRIPTION
Supersedes #648 (closed), which addressed the same N+1 query problem in `entity_tree.py`.

- [ ] I have added automatic tests where applicable.
- [x] The PR contains a description of what has been changed.
- [x] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [ ] MacOs.
- [ ] Linux.


# Overview
**Purpose:** Optimize ftrack server queries in Connect by adding explicit projections, eliminating N+1 lazy-attribute fetches.

**Scope:** `apps/connect` — entity tree model (`ui/model/entity_tree.py`), action launcher (`action_launcher/actions.py`), storage scenario widget (`ui/widget/configure_scenario.py`).

## Implementation Details
**Approach:** Add `select <attributes>` projections to queries so that attributes read downstream are fetched in the initial query instead of lazily per entity.

**Reasoning:** ftrack_api prepends `select id from` to bare queries, so any other attribute access triggers a per-entity fetch. Listing N active projects previously issued 1 + N requests (one per `full_name`); with the projection it is a single query.

**Changes:**
- `entity_tree.py`: `select id, full_name, name from Project where status is active` — the main win, removes the per-project `full_name` fetch when populating the project tree.
- `actions.py`: `select value from Metadata ...` saves one round trip when loading recent actions; `select id from User ...` is explicitness only (equivalent to the ftrack_api default projection).
- `configure_scenario.py`: `select id from Setting ...` (explicitness only, existence check); removed unused imports (`os`, `QtGui`, `QtSvg`).
- Quote/docstring churn comes from `ruff format` (`quote-style = "double"` per `apps/connect/pyproject.toml`).

**Trade-offs:** Projections must be kept in sync with the attributes the model reads (e.g. `Project.name` reads `full_name`); a missing attribute falls back to lazy loading rather than failing.

## Testing
**Tests Added:** None — UI/query-path change, covered by manual testing.

**Manual Testing:**
1. Launch Connect and open the Actions tab — the entity browser lists active projects by full name; with debug logging enabled, only a single `Project` query is issued (no per-project follow-up queries).
2. Expand a project — children load as before.
3. Launch an action — it appears under Recent and persists after restarting Connect (Metadata `value` path).
4. On a first-run/unconfigured workspace, the storage scenario screen renders and "Configure now" opens the browser (Setting path).

**Testing Environment:** macOS, Connect launched from source.

## Notes for Reviewers
**Focus Areas:** Projection completeness vs. attributes read downstream (`Project.name` → `full_name`, recent actions → `metadata['value']`).

**Dependencies:** None.

**Known Issues:** CodeRabbit's suggestion to escape `session.api_user` in the User query was resolved as out of scope — the interpolation predates this PR and the same pattern exists in several other call sites ([discussion](https://github.com/ftrackhq/integrations/pull/650#discussion_r3389063726)). Aikido's PR gate initially flagged 3 new criticals (`AIK_python_B608`, string-built queries) on the same queries — these appeared only because the added `select … from` projections made the strings pattern-match SQL. Triaged in the Aikido dashboard as not exploitable: this is the ftrack query language (not SQL) sent over the user's own authenticated session, and the interpolated values are a server-issued UUID, a class constant, and the user's own configured username.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for PySide6 alongside existing PySide2 for the configuration UI.

* **Improvements**
  * Improved project listing accuracy in the entity tree to return more precise project data.
  * Consistent UI text and overlay messaging for action discovery and launch flows.

* **Chores**
  * Standardized docstrings, string quoting, and UI text formatting across multiple modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
