### PR TITLE
fix: ensure correct session is used for usage tracker

### DIFF
--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -521,18 +521,24 @@ class Application(QtWidgets.QMainWindow):
             session
         )
 
-        # Initialize UsageTracker for connect
-        set_usage_tracker(
-            UsageTracker(
-                session=session,
-                default_data=dict(
-                    app="Connect",
-                    version=ftrack_connect.__version__,
-                    os=platform.platform(),
-                    python_version=platform.python_version(),
-                ),
+        # Initialize or update UsageTracker for connect
+        usage_tracker = get_usage_tracker()
+        if usage_tracker is None:
+            # First time - create the singleton
+            set_usage_tracker(
+                UsageTracker(
+                    session=session,
+                    default_data=dict(
+                        app="Connect",
+                        version=ftrack_connect.__version__,
+                        os=platform.platform(),
+                        python_version=platform.python_version(),
+                    ),
+                )
             )
-        )
+        else:
+            # Session has been recreated - update the reference
+            usage_tracker.update_session(session)
 
         return session
 

--- a/apps/connect/source/ftrack_connect/ui/application.py
+++ b/apps/connect/source/ftrack_connect/ui/application.py
@@ -702,6 +702,9 @@ class Application(QtWidgets.QMainWindow):
     def _configure_connect_and_discover_plugins(self):
         """Configure connect and load plugins."""
 
+        # Clear widget plugin instances to ensure they're recreated with new session
+        self._widget_plugin_instances.clear()
+
         self.tabPanel = _tab_widget.TabWidget()
         self.tabPanel.tabBar().setObjectName("application-tab-bar")
         self.setCentralWidget(self.tabPanel)

--- a/libs/utils/source/ftrack_utils/server/send_event.py
+++ b/libs/utils/source/ftrack_utils/server/send_event.py
@@ -33,14 +33,13 @@ def send_event(session, action, event_name, metadata=None):
 
     except Exception as exc:
         # Log but don't raise - usage tracking should never break the application
-        logger.debug(
-            'Failed to send event "{}" ({}): {}'.format(
-                event_name, exc.__class__.__name__, exc
-            )
+        logger.warning(
+            'Failed to send event "{}": {}'.format(event_name, exc),
+            exc_info=True,
         )
 
 
 @asynchronous
 def send_async_event(session, action, event_name, metadata=None):
-    """Call __send_event in a new thread."""
+    """Call send_event in a new thread."""
     send_event(session, action, event_name, metadata)

--- a/libs/utils/source/ftrack_utils/server/send_event.py
+++ b/libs/utils/source/ftrack_utils/server/send_event.py
@@ -6,11 +6,11 @@ import logging
 from ftrack_utils.decorators import asynchronous
 
 
-logger = logging.getLogger('ftrack_utils:server.send_event')
+logger = logging.getLogger("ftrack_utils:server.send_event")
 
 
 def send_event(session, action, event_name, metadata=None):
-    '''Send usage event with *event_name* and *metadata*.'''
+    """Send usage event with *event_name* and *metadata*."""
 
     if not isinstance(metadata, list):
         metadata = [metadata]
@@ -19,11 +19,11 @@ def send_event(session, action, event_name, metadata=None):
     for data in metadata:
         payload.append(
             {
-                'action': action,
-                'data': {
-                    'type': 'event',
-                    'name': event_name,
-                    'metadata': data,
+                "action": action,
+                "data": {
+                    "type": "event",
+                    "name": event_name,
+                    "metadata": data,
                 },
             }
         )
@@ -31,11 +31,16 @@ def send_event(session, action, event_name, metadata=None):
     try:
         session.call(payload)
 
-    except Exception:
-        logger.exception('Failed to send event : {}'.format(event_name))
+    except Exception as exc:
+        # Log but don't raise - usage tracking should never break the application
+        logger.debug(
+            'Failed to send event "{}" ({}): {}'.format(
+                event_name, exc.__class__.__name__, exc
+            )
+        )
 
 
 @asynchronous
 def send_async_event(session, action, event_name, metadata=None):
-    '''Call __send_event in a new thread.'''
+    """Call __send_event in a new thread."""
     send_event(session, action, event_name, metadata)

--- a/libs/utils/source/ftrack_utils/usage/track_usage.py
+++ b/libs/utils/source/ftrack_utils/usage/track_usage.py
@@ -6,7 +6,7 @@ import copy
 
 from ftrack_utils.server.track_usage import send_usage_event
 
-logger = logging.getLogger('ftrack_utils:usage')
+logger = logging.getLogger("ftrack_utils:usage")
 
 # Singleton instance placeholder
 usage_tracker_singleton = None
@@ -54,6 +54,15 @@ class UsageTracker:
             cls._instance._session = session
             cls._instance._default_data = default_data
         return cls._instance
+
+    def update_session(self, session):
+        """
+        Update the session reference when it has been recreated.
+
+        *session*: The new ftrack_api.Session instance to use.
+        """
+        self._session = session
+        logger.debug("Updated UsageTracker session reference")
 
     def track(self, event_name, metadata):
         """


### PR DESCRIPTION
resolve usage event emission error due to double session cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed usage tracking initialization to reuse the existing tracker when sessions are recreated, keeping tracker state consistent.
  * Ensured widget plugin instances are cleared and rebuilt so newly created session context is applied correctly.

* **Chores**
  * Improved server event logging setup, messaging, and error reporting (without changing behavior on failures).
  * Updated usage tracking logger naming and added a method to update the tracker’s session reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->