### PR TITLE
fix(houdini): load menu on Houdini 21; fix styling; Ftrack branding

### DIFF
--- a/libs/qt-style/source/ftrack_qt_style/resource.py
+++ b/libs/qt-style/source/ftrack_qt_style/resource.py
@@ -3,7 +3,10 @@
 # Created by: The Resource Compiler for Qt version 6.6.3
 # WARNING! All changes made in this file will be lost!
 
-from PySide6 import QtCore
+try:
+    from PySide6 import QtCore
+except ImportError:
+    from PySide2 import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x08\xd3\

--- a/libs/qt/source/ftrack_qt/widgets/browsers/entity_browser.py
+++ b/libs/qt/source/ftrack_qt/widgets/browsers/entity_browser.py
@@ -147,7 +147,7 @@ class EntityBrowser(ModalDialog):
         self.mode = mode or EntityBrowser.MODE_TASK
 
         super(EntityBrowser, self).__init__(
-            parent, question=True, title=title or 'ftrack Entity Browser'
+            parent, question=True, title=title or 'Ftrack Entity Browser'
         )
 
         if entity:

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/modal_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/modal_dialog.py
@@ -42,7 +42,7 @@ class ModalDialog(StyledDialog):
         self.setParent(parent)
 
         self._message = message
-        self._title = title or 'ftrack'
+        self._title = title or 'Ftrack'
         self._question = question
 
         self._approve_button = None

--- a/libs/qt/source/ftrack_qt/widgets/dialogs/styled_dialog.py
+++ b/libs/qt/source/ftrack_qt/widgets/dialogs/styled_dialog.py
@@ -81,4 +81,4 @@ class StyledDialog(QtWidgets.QDialog):
         self.setWindowFlags(QtCore.Qt.WindowType.WindowStaysOnTopHint)
 
         # Have a proper title instead of default 'python'
-        self.setWindowTitle('ftrack')
+        self.setWindowTitle('Ftrack')

--- a/libs/qt/source/ftrack_qt/widgets/logos/ftrack_logo.py
+++ b/libs/qt/source/ftrack_qt/widgets/logos/ftrack_logo.py
@@ -36,4 +36,4 @@ class FtrackLogo(QtWidgets.QLabel):
             )
             self.setPixmap(logoPixmap)
         else:
-            self.setText("ftrack")
+            self.setText("Ftrack")

--- a/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_opener_dialog.py
@@ -60,7 +60,7 @@ class StandardOpenerDialog(BaseContextDialog):
             parent=parent,
         )
         self.resize(400, 450)
-        self.setWindowTitle('ftrack Opener')
+        self.setWindowTitle('Ftrack Opener')
 
     def pre_build_ui(self):
         pass

--- a/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
+++ b/projects/framework-common-extensions/dialogs/standard_publisher_dialog.py
@@ -64,7 +64,7 @@ class StandardPublisherDialog(BaseContextDialog):
             dialog_options,
             parent=parent,
         )
-        self.setWindowTitle('ftrack Publisher')
+        self.setWindowTitle('Ftrack Publisher')
 
     def pre_build_ui(self):
         # Make sure to remove self._scroll_area in case of reload

--- a/projects/framework-houdini/pyproject.toml
+++ b/projects/framework-houdini/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ftrack-framework-houdini"
-version = "26.3.0rc1"
+version = "26.7.0rc1"
 description = "ftrack Houdini integration"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/projects/framework-houdini/release_notes.md
+++ b/projects/framework-houdini/release_notes.md
@@ -1,5 +1,14 @@
 # ftrack Framework Houdini integration release Notes
 
+## v26.7.0rc1
+2026-06-29
+
+* [changed] Branding; capitalized user-facing "ftrack" labels and dialog/window titles to "Ftrack", including the Houdini main menu.
+* [fix] Menu; Refresh the Houdini startup search-path cache after writing the menu file so the ftrack menu appears on Houdini 21+. Houdini 21 caches search paths early in startup and otherwise never discovers the dynamically generated MainMenuCommon.xml.
+* [changed] Python panel; Docked Python panel left disabled (publisher floats, consistent with the other DCC integrations); embedding the dialog into a Houdini Python Panel crashes on Qt6 / Houdini 21.
+* [fix] Styling; ftrack dialogs are now styled on Houdini < 21 (PySide2/Qt5). The bundled ftrack-qt-style resource imported PySide6 unconditionally, which failed on PySide2 Houdini and left dialogs with Houdini's default style; the import now falls back to PySide2.
+* [changed] Build; migrated the build system and formatting to uv/ruff.
+
 ## v24.11.0
 2024-11-21
 

--- a/projects/framework-houdini/release_notes.md
+++ b/projects/framework-houdini/release_notes.md
@@ -1,6 +1,6 @@
 # ftrack Framework Houdini integration release Notes
 
-## v26.7.0rc1
+## v26.7.0
 2026-06-29
 
 * [changed] Branding; capitalized user-facing "ftrack" labels and dialog/window titles to "Ftrack", including the Houdini main menu.

--- a/projects/framework-houdini/source/ftrack_framework_houdini/__init__.py
+++ b/projects/framework-houdini/source/ftrack_framework_houdini/__init__.py
@@ -68,7 +68,7 @@ def get_ftrack_menu():
     menubar = ET.SubElement(root, "menuBar")
     ftrack_menu = ET.SubElement(menubar, "subMenu")
     label = ET.SubElement(ftrack_menu, "label")
-    label.text = "ftrack"
+    label.text = "Ftrack"
     insert_before = ET.SubElement(ftrack_menu, "insertBefore")
     insert_before.text = "help_menu"
     return (root, ftrack_menu)
@@ -201,6 +201,14 @@ def bootstrap_integration(framework_extensions_path):
     with open(xml_path, "w") as xml_file_handle:
         xml_file_handle.write(xml)
         xml_file_handle.close()
+
+    # Houdini 21+ caches search paths at startup, so the MainMenuCommon.xml
+    # written above is not seen when the menu bar is built and the ftrack
+    # menu never appears. Refreshing the directory we wrote to makes it
+    # discoverable in this session. The method is absent on Houdini <= 20.5,
+    # which has no such cache and needs no refresh.
+    if hasattr(hou, "refreshStartupPathCacheDirectory"):
+        hou.refreshStartupPathCacheDirectory(xml_menu_file_folder)
 
     return client_instance
 

--- a/projects/framework-houdini/source/ftrack_framework_houdini/utils/__init__.py
+++ b/projects/framework-houdini/source/ftrack_framework_houdini/utils/__init__.py
@@ -2,65 +2,21 @@
 # :copyright: Copyright (c) 2024 ftrack
 
 import threading
-import xml.etree.ElementTree as ET
-from xml.sax.saxutils import unescape
-import os
 
-from ftrack_utils.paths import get_temp_path
-
-import hou
 from hdefereval import executeInMainThreadWithResult
 
-created_widgets = dict()
 
-
-# Dock widget in Houdini
+# Show widget in Houdini
 def dock_houdini_right(widget):
-    '''Dock *widget* to the right side of Houdini.'''
+    '''Show *widget* as a floating window in Houdini.
+
+    Docking into a Houdini Python Panel is intentionally not enabled: no other
+    DCC integration docks (Maya/Nuke float, Blender passes no dock function),
+    and embedding the dialog into a Python Panel segfaults on Qt6 / Houdini 21
+    (the ftrack_qt StyledDialog is a top-level QDialog flagged WA_DeleteOnClose
+    and WindowStaysOnTopHint). Shown floating instead, like the other DCCs.
+    '''
     widget.show()
-    # TODO: To provide docking functionality, comment line above and uncomment code below
-    # class_name = widget.__class__.__name__
-    #
-    # if class_name not in globals():
-    #     globals()[class_name] = lambda *args, **kwargs: widget
-    #
-    # created_widgets[class_name] = widget
-    #
-    # panel_xml = _generate_pypanel_xml(class_name)
-    # xml = unescape(ET.tostring(panel_xml).decode())
-    #
-    # xml_path = get_temp_path('pypanel')
-    #
-    # if not os.path.exists(os.path.dirname(xml_path)):
-    #     os.makedirs(os.path.dirname(xml_path))
-    #
-    # with open(xml_path, "w") as xml_file_handle:
-    #     xml_file_handle.write(xml)
-    #     xml_file_handle.close()
-    #
-    # hou.pypanel.installFile(xml_path)
-    #
-    # panel_interface = None
-    #
-    # try:
-    #     for interface, value in hou.pypanel.interfaces().items():
-    #         if interface == "ftrack Publish panel":
-    #             panel_interface = value
-    #             break
-    # except hou.OperationFailed as e:
-    #     hou.ui.displayMessage("Something wrong with Python Panel")
-    #
-    # main_tab = hou.ui.curDesktop().findPaneTab("Ftrack_ID")
-    # if main_tab:
-    #     panel = main_tab.pane().createTab(hou.paneTabType.PythonPanel)
-    #     panel.showToolbar(True)
-    #     panel.setActiveInterface(panel_interface)
-    # else:
-    #     if panel_interface:
-    #         hou.hscript('pane -S -m pythonpanel -o -n {}'.format("Ftrack_ID"))
-    #         panel = hou.ui.curDesktop().findPaneTab("Ftrack_ID")
-    #         panel.showToolbar(True)
-    #         panel.setActiveInterface(panel_interface)
 
 
 def run_in_main_thread(f):
@@ -73,39 +29,3 @@ def run_in_main_thread(f):
             return f(*args, **kwargs)
 
     return decorated
-
-
-def _generate_pypanel_xml(widget_name):
-    '''Write temporary xml file for pypanel'''
-
-    root = ET.Element("pythonPanelDocument")
-    interface = ET.SubElement(root, "interface")
-    interface.set("name", "ftrack Publish panel")
-    interface.set("label", "ftrack Publish panel")
-    interface.set("icon", "MISC_python")
-    interface.set("help_url", "")
-    script = ET.SubElement(interface, "script")
-    script.text = """
-<![CDATA[
-from PySide2.QtWidgets import QWidget, QVBoxLayout
-import __main__
-layout = QVBoxLayout()
-layout.addWidget(__main__.ftrack_framework_houdini.utils.created_widgets['{}'])
-def get_widget():
-    widget = QWidget()
-    widget.setLayout(layout)
-    return widget
-def onCreateInterface():
-    '''For Houdini >=20'''
-    return get_widget()
-def createInterface():
-    '''For Houdini <20'''
-    return get_widget()
-]]>
-""".format(
-        widget_name
-    )
-    help = ET.SubElement(interface, "help")
-    help.text = "<![CDATA[]]>"
-
-    return root

--- a/projects/framework-houdini/uv.lock
+++ b/projects/framework-houdini/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.13.*"
 
 [[package]]
@@ -127,7 +127,7 @@ provides-extras = ["ftrack-libs", "documentation"]
 
 [[package]]
 name = "ftrack-framework-houdini"
-version = "26.3.0rc1"
+version = "26.7.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "ftrack-python-api" },

--- a/tools/build.py
+++ b/tools/build.py
@@ -614,12 +614,15 @@ def build_package(invokation_path, pkg_path, args, command=None):
         for line in fileinput.input(
             resource_target_path, inplace=True, mode="r"
         ):
-            # Check if the line contains an import statement we want to replace
-            if "from PySide2 import QtCore" in line:
-                # Print the new import block instead of the old line
+            # Replace the bare top-level Qt import (PySide2 or PySide6, as
+            # emitted by pyside*-rcc) with a cross-version import block. The
+            # leading-whitespace check keeps this idempotent: the indented
+            # imports inside new_imports are not matched.
+            if line.startswith(
+                ("from PySide2 import QtCore", "from PySide6 import QtCore")
+            ):
                 sys.stdout.write(new_imports)
             else:
-                # Otherwise, print the line unchanged
                 sys.stdout.write(line)
 
     def build_qt_resources(args):


### PR DESCRIPTION
Resolves [F-1080](https://linear.app/iconik/issue/F-1080/)

- [ ] I have added automatic tests where applicable.
- [ ] The PR contains a description of what has been changed.
- [ ] The description contains manual test instructions.
- [ ] The PR contains update to the release notes.
- [ ] The PR contains update to the documentation.

This PR has been tested on :

- [ ] Windows.
- [x] MacOs.
- [ ] Linux.


# Overview
**Purpose:** Fix the ftrack Houdini integration not loading through Connect on Houdini 21 (no menu, no panel), restore dialog styling on older Houdini versions, and capitalize user-facing "ftrack" to "Ftrack".

**Scope:** `projects/framework-houdini` (menu bootstrap, docking, version, release notes), shared `libs/qt` and `libs/qt-style` (dialog titles, styling resource), `projects/framework-common-extensions` (publisher/opener dialog titles), and `tools/build.py`.

## Implementation Details
**Approach:**
- **Houdini 21 menu:** Houdini 21 added a startup search-path cache that snapshots directories before the integration writes its generated `MainMenuCommon.xml`, so the ftrack menu never appeared. After writing the file we now call `hou.refreshStartupPathCacheDirectory(...)`, guarded by `hasattr` so it is a no-op on Houdini <= 20.5.
- **Publisher:** kept floating instead of docking into a Python Panel — embedding the dialog segfaults on Qt6/Houdini 21 and no other DCC integration docks; the unused docking code was removed from `utils`.
- **Styling on older Houdini:** `ftrack_qt_style/resource.py` imported PySide6 unconditionally and failed on PySide2 Houdini (< 21), silently disabling all dialog styling. It now imports `QtCore` with a PySide6 -> PySide2 fallback, and `tools/build.py` `_replace_imports_` rewrites a PySide6-generated import line too so future resource regenerations stay cross-version.
- **Branding:** capitalized "ftrack" -> "Ftrack" in the main menu label and the dialog/window titles (StyledDialog, ModalDialog, entity browser, logo fallback, and the publisher/opener titles).

**Reasoning:** The cache refresh keeps the existing dynamic menu generation working on Houdini 21 with a one-line, version-guarded change; floating the publisher matches the other DCC integrations and avoids the Qt6 embed crash; the PySide fallback matches the pattern already used throughout `ftrack_qt`.

**Changes:** Bumps `ftrack-framework-houdini` to `26.7.0rc1` and consolidates the changes since 24.11.0 into its release notes.

**Trade-offs:** The docked Python panel is dropped (for consistency with other DCCs and Qt6 stability). The `ftrack_qt` / `ftrack_qt_style` changes are shared, so other already-released DCC plugins only pick them up once those libraries are republished; the Houdini plugin bundles them from source.

## Testing
**Tests Added:** None — UI / DCC-runtime behaviour.

**Manual Testing:** Built and deployed the Connect plugin and launched Houdini via ftrack Connect. On Houdini 21 the ftrack menu appears, Publish/Open launch and are styled, their title bars read "Ftrack Publisher" / "Ftrack Opener", and the startup scene-setup tool runs. On Houdini 20.5 / 20.0 the dialogs are styled again (no more "Styling resource file not found").

**Testing Environment:** macOS; Houdini 21, 20.5 and 20.0 via ftrack Connect.

## Notes for Reviewers
**Focus Areas:** The `hou.refreshStartupPathCacheDirectory` call in `framework-houdini/.../__init__.py` (guarded for <= 20.5), and the shared `ftrack_qt_style/resource.py` + `tools/build.py` import handling.

**Dependencies:** None.

**Known Issues:** Houdini <= 19 (Python 3.7) still won't auto-bootstrap (no `python3.7libs`), which was deprioritized. The shared `ftrack_qt` / `ftrack_qt_style` branding and styling fixes reach other DCC plugins only after those libraries are republished.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Houdini tools now use updated “Ftrack” branding across dialogs, logos, and menu labels.
  * Houdini startup menus are refreshed automatically so newly generated menus appear in the current session.

* **Bug Fixes**
  * Improved compatibility with multiple Qt/PySide versions.
  * Fixed Houdini panel and docking behavior for better stability on newer versions.
  * Preserved the correct UI style on older Houdini versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->